### PR TITLE
Basic GCW regions

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/gameplay/player/ActivePlayerPredicate.java
+++ b/src/main/java/com/projectswg/holocore/resources/gameplay/player/ActivePlayerPredicate.java
@@ -1,3 +1,29 @@
+/***********************************************************************************
+ * Copyright (c) 2018 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
 package com.projectswg.holocore.resources.gameplay.player;
 
 import com.projectswg.common.data.encodables.tangible.Posture;

--- a/src/main/java/com/projectswg/holocore/resources/gameplay/player/ActivePlayerPredicate.java
+++ b/src/main/java/com/projectswg/holocore/resources/gameplay/player/ActivePlayerPredicate.java
@@ -1,0 +1,24 @@
+package com.projectswg.holocore.resources.gameplay.player;
+
+import com.projectswg.common.data.encodables.tangible.Posture;
+import com.projectswg.holocore.resources.support.global.player.Player;
+import com.projectswg.holocore.resources.support.global.player.PlayerFlags;
+import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject;
+import com.projectswg.holocore.resources.support.objects.swg.player.PlayerObject;
+
+import java.util.function.Predicate;
+
+public class ActivePlayerPredicate implements Predicate<Player> {
+	@Override
+	public boolean test(Player player) {
+		CreatureObject creatureObject = player.getCreatureObject();
+		PlayerObject playerObject = creatureObject.getPlayerObject();
+		boolean afk = playerObject.isFlagSet(PlayerFlags.AFK);
+		boolean offline = playerObject.isFlagSet(PlayerFlags.LD);
+		boolean incapacitated = creatureObject.getPosture() == Posture.INCAPACITATED;
+		boolean dead = creatureObject.getPosture() == Posture.DEAD;
+		boolean cloaked = !creatureObject.isVisible();
+		
+		return !afk && !offline && !incapacitated && !dead && !cloaked;
+	}
+}

--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/DataLoader.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/DataLoader.kt
@@ -56,7 +56,8 @@ abstract class DataLoader {
 		fun vehicles(): VehicleLoader = ServerData.vehicles
 		fun specialLines(): SpecialLineLoader = ServerData.specialLines
 		fun staticPvpZones(): StaticPvpZoneLoader = ServerData.staticPvpZones
-		
+		fun gcwRegionLoader(): GcwRegionLoader = ServerData.gcwRegionLoader
+
 	}
 	
 }

--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/GcwRegionLoader.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/GcwRegionLoader.java
@@ -1,0 +1,96 @@
+/***********************************************************************************
+ * Copyright (c) 2018 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.resources.support.data.server_info.loader;
+
+import com.projectswg.common.data.location.Terrain;
+import com.projectswg.holocore.resources.support.data.server_info.SdbLoader;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+public class GcwRegionLoader extends DataLoader {
+	
+	private final Map<Terrain, Collection<GcwRegionInfo>> regions;
+	
+	public GcwRegionLoader() {
+		regions = new HashMap<>();
+	}
+	
+	@NotNull
+	public Map<Terrain, Collection<GcwRegionInfo>> getRegionsByTerrain() {
+		return Collections.unmodifiableMap(regions);
+	}
+	
+	@Override
+	public void load() throws IOException {
+		try (SdbLoader.SdbResultSet set = SdbLoader.load(new File("serverdata/nge/gcw/regions_gcw.sdb"))) {
+			while (set.next()) {
+				GcwRegionInfo regionInfo = new GcwRegionInfo(set);
+				
+				regions.computeIfAbsent(regionInfo.getTerrain(), a -> new ArrayList<>()).add(regionInfo);
+			}
+		}
+	}
+	
+	public static class GcwRegionInfo {
+		private final Terrain terrain;
+		private final String regionName;
+		private final long centerX;
+		private final long centerZ;
+		private final long radius;
+		
+		public GcwRegionInfo(SdbLoader.SdbResultSet set) {
+			terrain = Terrain.getTerrainFromName(set.getText("terrain"));
+			regionName = set.getText("regionName");
+			centerX = set.getInt("centerX");
+			centerZ = set.getInt("centerZ");
+			radius = set.getInt("radius");
+		}
+		
+		public Terrain getTerrain() {
+			return terrain;
+		}
+		
+		public String getRegionName() {
+			return regionName;
+		}
+		
+		public long getCenterX() {
+			return centerX;
+		}
+		
+		public long getCenterZ() {
+			return centerZ;
+		}
+		
+		public long getRadius() {
+			return radius;
+		}
+	}
+}

--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/ServerData.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/ServerData.kt
@@ -92,7 +92,8 @@ object ServerData {
 	val travelCosts			by SoftDataLoaderDelegate(::TravelCostLoader)
 	val vehicles			by SoftDataLoaderDelegate(::VehicleLoader)
 	val staticPvpZones		by SoftDataLoaderDelegate(::StaticPvpZoneLoader)
-	
+	val gcwRegionLoader		by SoftDataLoaderDelegate(::GcwRegionLoader)
+
 	private class WeakDataLoaderDelegate<T: DataLoader>(loaderCreator: () -> T): DataLoaderDelegate<T>(::WeakReference, loaderCreator)
 	private class SoftDataLoaderDelegate<T: DataLoader>(loaderCreator: () -> T): DataLoaderDelegate<T>(::SoftReference, loaderCreator)
 	

--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/mongodb/PswgDatabase.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/mongodb/PswgDatabase.kt
@@ -19,7 +19,8 @@ object PswgDatabase {
 	val users by DatabaseDelegate(database, "users") { PswgUserDatabase(it?.withWriteConcern(WriteConcern.ACKNOWLEDGED)) }
 	val objects by DatabaseDelegate(database, "objects") { PswgObjectDatabase(it?.withWriteConcern(WriteConcern.JOURNALED)) }
 	val resources by DatabaseDelegate(database, "resources") { PswgResourceDatabase(it?.withWriteConcern(WriteConcern.ACKNOWLEDGED)) }
-	
+	val gcwRegions by DatabaseDelegate(database, "gcwregions") { PswgGcwRegionDatabase(it?.withWriteConcern(WriteConcern.ACKNOWLEDGED)) }
+
 	fun initialize(connectionString: String, databaseName: String) {
 		setupMongoLogging()
 		val client = MongoClients.create(connectionString)

--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/mongodb/PswgGcwRegionDatabase.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/mongodb/PswgGcwRegionDatabase.kt
@@ -41,15 +41,15 @@ class PswgGcwRegionDatabase(private val collection: MongoCollection<Document>?) 
 		collection?.createIndex(Indexes.ascending("zone"), IndexOptions().unique(true))
 	}
 
-	fun createZone(zoneName: String) {
+	fun createZone(zoneName: String, basePoints: Long) {
 		collection ?: return
 
 		val mongoData = MongoData()
 
 		// Initiualize a zone with some points. We do this so gaining 100% control can't be done by being the first to receive any amount of GCW points.
 		mongoData.putString("zone", zoneName)
-		mongoData.putLong("imperialPoints", CivilWarRegionService.BASE_ZONE_POINTS)
-		mongoData.putLong("rebelPoints", CivilWarRegionService.BASE_ZONE_POINTS)
+		mongoData.putLong("imperialPoints", basePoints)
+		mongoData.putLong("rebelPoints", basePoints)
 
 		collection.insertOne(mongoData.toDocument())
 	}

--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/mongodb/PswgGcwRegionDatabase.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/mongodb/PswgGcwRegionDatabase.kt
@@ -32,6 +32,7 @@ import com.mongodb.client.model.Filters
 import com.mongodb.client.model.IndexOptions
 import com.mongodb.client.model.Indexes
 import com.projectswg.common.data.encodables.mongo.MongoData
+import com.projectswg.holocore.services.gameplay.gcw.CivilWarRegionService
 import org.bson.Document
 
 class PswgGcwRegionDatabase(private val collection: MongoCollection<Document>?) {
@@ -47,13 +48,13 @@ class PswgGcwRegionDatabase(private val collection: MongoCollection<Document>?) 
 
 		// Initiualize a zone with some points. We do this so gaining 100% control can't be done by being the first to receive any amount of GCW points.
 		mongoData.putString("zone", zoneName)
-		mongoData.putLong("imperialPoints", 50_000)
-		mongoData.putLong("rebelPoints", 50_000)
+		mongoData.putLong("imperialPoints", CivilWarRegionService.BASE_ZONE_POINTS)
+		mongoData.putLong("rebelPoints", CivilWarRegionService.BASE_ZONE_POINTS)
 
 		collection.insertOne(mongoData.toDocument())
 	}
 
-	fun addImperialPoints(zoneName: String, points: Long) {
+	fun setImperialPoints(zoneName: String, points: Long) {
 		collection ?: return
 		val mongoData = MongoData()
 
@@ -62,7 +63,7 @@ class PswgGcwRegionDatabase(private val collection: MongoCollection<Document>?) 
 		collection.updateOne(Filters.eq("zone", zoneName), Document("\$set", mongoData.toDocument()))
 	}
 
-	fun addRebelPoints(zoneName: String, points: Long) {
+	fun setRebelPoints(zoneName: String, points: Long) {
 		collection ?: return
 		val mongoData = MongoData()
 

--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/mongodb/PswgGcwRegionDatabase.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/mongodb/PswgGcwRegionDatabase.kt
@@ -1,0 +1,94 @@
+/***********************************************************************************
+ * Copyright (c) 2019 /// Project SWG /// www.projectswg.com                       *
+ * *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ * *
+ * This file is part of Holocore.                                                  *
+ * *
+ * --------------------------------------------------------------------------------*
+ * *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ * *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ * *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http:></http:>//www.gnu.org/licenses/>.               *
+ */
+
+package com.projectswg.holocore.resources.support.data.server_info.mongodb
+
+import com.mongodb.client.MongoCollection
+import com.mongodb.client.model.Filters
+import com.mongodb.client.model.IndexOptions
+import com.mongodb.client.model.Indexes
+import com.projectswg.common.data.encodables.mongo.MongoData
+import org.bson.Document
+
+class PswgGcwRegionDatabase(private val collection: MongoCollection<Document>?) {
+	
+	init {
+		collection?.createIndex(Indexes.ascending("zone"), IndexOptions().unique(true))
+	}
+
+	fun createZone(zoneName: String) {
+		collection ?: return
+
+		val mongoData = MongoData()
+
+		// Initiualize a zone with some points. We do this so gaining 100% control can't be done by being the first to receive any amount of GCW points.
+		mongoData.putString("zone", zoneName)
+		mongoData.putLong("imperialPoints", 50_000)
+		mongoData.putLong("rebelPoints", 50_000)
+
+		collection.insertOne(mongoData.toDocument())
+	}
+
+	fun addImperialPoints(zoneName: String, points: Long) {
+		collection ?: return
+		val mongoData = MongoData()
+
+		mongoData.putLong("imperialPoints", points)
+
+		collection.updateOne(Filters.eq("zone", zoneName), Document("\$set", mongoData.toDocument()))
+	}
+
+	fun addRebelPoints(zoneName: String, points: Long) {
+		collection ?: return
+		val mongoData = MongoData()
+
+		mongoData.putLong("rebelPoints", points)
+
+		collection.updateOne(Filters.eq("zone", zoneName), Document("\$set", mongoData.toDocument()))
+	}
+
+	fun getZone(zoneName: String): ZoneMetadata? {
+		return collection
+				?.find(Filters.eq("zone", zoneName))
+				?.map { ZoneMetadata(it) }
+				?.first()
+	}
+	
+}
+
+class ZoneMetadata(doc: Document) {
+	
+	val _id: String = doc.getObjectId("_id").toHexString()
+	val zone: String = doc.getString("zone")
+	val imperialPoints: Long = doc.getLong("imperialPoints")
+	val rebelPoints: Long = doc.getLong("rebelPoints")
+
+	override fun toString(): String = "ZoneMetadata[zone=$zone imperialPoints=$imperialPoints rebelPoints=$rebelPoints]"
+	override fun equals(other: Any?): Boolean = if (other is ZoneMetadata) zone == other.zone else false
+	override fun hashCode(): Int = zone.hashCode()
+	
+}

--- a/src/main/java/com/projectswg/holocore/resources/support/global/commands/callbacks/generic/CmdStopDance.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/global/commands/callbacks/generic/CmdStopDance.java
@@ -1,6 +1,6 @@
 package com.projectswg.holocore.resources.support.global.commands.callbacks.generic;
 
-import com.projectswg.holocore.intents.gameplay.entertainment.dance.DanceIntent;
+import com.projectswg.holocore.intents.gameplay.gcw.faction.CivilWarPointIntent;
 import com.projectswg.holocore.resources.support.global.commands.ICmdCallback;
 import com.projectswg.holocore.resources.support.global.player.Player;
 import com.projectswg.holocore.resources.support.objects.swg.SWGObject;
@@ -10,7 +10,7 @@ public final class CmdStopDance implements ICmdCallback {
 	
 	@Override
 	public void execute(@NotNull Player player, SWGObject target, @NotNull String args) {
-		new DanceIntent(player.getCreatureObject()).broadcast();
+		CivilWarPointIntent.broadcast(player.getPlayerObject(), 1000);
 	}
 	
 }

--- a/src/main/java/com/projectswg/holocore/resources/support/global/commands/callbacks/generic/CmdStopDance.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/global/commands/callbacks/generic/CmdStopDance.java
@@ -1,6 +1,6 @@
 package com.projectswg.holocore.resources.support.global.commands.callbacks.generic;
 
-import com.projectswg.holocore.intents.gameplay.gcw.faction.CivilWarPointIntent;
+import com.projectswg.holocore.intents.gameplay.entertainment.dance.DanceIntent;
 import com.projectswg.holocore.resources.support.global.commands.ICmdCallback;
 import com.projectswg.holocore.resources.support.global.player.Player;
 import com.projectswg.holocore.resources.support.objects.swg.SWGObject;
@@ -10,7 +10,7 @@ public final class CmdStopDance implements ICmdCallback {
 	
 	@Override
 	public void execute(@NotNull Player player, SWGObject target, @NotNull String args) {
-		CivilWarPointIntent.broadcast(player.getPlayerObject(), 1000);
+		new DanceIntent(player.getCreatureObject()).broadcast();
 	}
 	
 }

--- a/src/main/java/com/projectswg/holocore/resources/support/objects/awareness/AwarenessType.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/awareness/AwarenessType.java
@@ -35,7 +35,8 @@ public enum AwarenessType {
 	SELF,
 	OBJECT,
 	GROUP,
-	TRADE;
+	TRADE,
+	GUILD;
 	
 	private static final Collection<AwarenessType> VALUES = Collections.unmodifiableCollection(Arrays.asList(values()));
 	

--- a/src/main/java/com/projectswg/holocore/resources/support/objects/swg/guild/GuildObject.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/swg/guild/GuildObject.java
@@ -54,6 +54,7 @@ public class GuildObject extends SWGObject {
 	protected void createBaseline3(Player target, BaselineBuilder bb) {
 		super.createBaseline3(target, bb);
 		bb.addObject(abbreviations);
+		bb.incrementOperandCount(1);
 	}
 	
 	@Override
@@ -65,6 +66,8 @@ public class GuildObject extends SWGObject {
 		bb.addObject(gcwGroupImperialScorePercentileHistoryThisGalaxy);
 		bb.addObject(gcwImperialScorePercentileOtherGalaxies);
 		bb.addObject(gcwGroupImperialScorePercentileOtherGalaxies);
+		bb.addInt(0);	// unknown, but client underflows if there aren't 4 bytes here
+		bb.incrementOperandCount(8);
 	}
 	
 	@Override
@@ -82,6 +85,7 @@ public class GuildObject extends SWGObject {
 		gcwGroupImperialScorePercentileHistoryThisGalaxy = SWGMap.getSwgMap(buffer, 6, 5, StringType.ASCII, CurrentServerGCWZoneHistory.class);
 		gcwImperialScorePercentileOtherGalaxies = SWGMap.getSwgMap(buffer, 6, 6, StringType.ASCII, OtherServerGCWZonePercent.class);
 		gcwGroupImperialScorePercentileOtherGalaxies = SWGMap.getSwgMap(buffer, 6, 7, StringType.ASCII, OtherServerGCWZonePercent.class);
+		// unknown variable
 	}
 	
 	public static class CurrentServerGCWZonePercent implements Encodable {

--- a/src/main/java/com/projectswg/holocore/resources/support/objects/swg/guild/GuildObject.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/swg/guild/GuildObject.java
@@ -71,7 +71,7 @@ public class GuildObject extends SWGObject {
 		bb.addObject(gcwImperialScorePercentileOtherGalaxies);
 		bb.addObject(gcwGroupImperialScorePercentileOtherGalaxies);
 		bb.addInt(0);	// unknown, but client underflows if there aren't 4 bytes here
-		bb.incrementOperandCount(8);
+		bb.incrementOperandCount(7);
 	}
 	
 	@Override

--- a/src/main/java/com/projectswg/holocore/resources/support/objects/swg/guild/GuildObject.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/swg/guild/GuildObject.java
@@ -26,6 +26,8 @@
  ***********************************************************************************/
 package com.projectswg.holocore.resources.support.objects.swg.guild;
 
+import com.projectswg.common.data.encodables.mongo.MongoData;
+import com.projectswg.common.data.location.Terrain;
 import com.projectswg.common.encoding.Encodable;
 import com.projectswg.common.encoding.StringType;
 import com.projectswg.common.network.NetBuffer;
@@ -35,16 +37,18 @@ import com.projectswg.holocore.resources.support.data.collections.SWGSet;
 import com.projectswg.holocore.resources.support.global.network.BaselineBuilder;
 import com.projectswg.holocore.resources.support.global.player.Player;
 import com.projectswg.holocore.resources.support.objects.swg.SWGObject;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class GuildObject extends SWGObject {
 	
 	private SWGSet<String> abbreviations = new SWGSet<>(3, 4, StringType.ASCII);
-	private SWGMap<String, CurrentServerGCWZonePercent> gcwImperialScorePercentileThisGalaxy = new SWGMap<>(6, 2);
-	private SWGMap<String, CurrentServerGCWZonePercent> gcwGroupImperialScorePercentileThisGalaxy = new SWGMap<>(6, 3);
-	private SWGMap<String, CurrentServerGCWZoneHistory> gcwImperialScorePercentileHistoryThisGalaxy = new SWGMap<>(6, 4);
-	private SWGMap<String, CurrentServerGCWZoneHistory> gcwGroupImperialScorePercentileHistoryThisGalaxy = new SWGMap<>(6, 5);
-	private SWGMap<String, OtherServerGCWZonePercent> gcwImperialScorePercentileOtherGalaxies = new SWGMap<>(6, 6);
-	private SWGMap<String, OtherServerGCWZonePercent> gcwGroupImperialScorePercentileOtherGalaxies = new SWGMap<>(6, 7);
+	private SWGMap<String, CurrentServerGCWZonePercent> gcwImperialScorePercentileThisGalaxy = new SWGMap<>(6, 2, StringType.ASCII);
+	private SWGMap<String, CurrentServerGCWZonePercent> gcwGroupImperialScorePercentileThisGalaxy = new SWGMap<>(6, 3, StringType.ASCII);
+	private SWGMap<String, CurrentServerGCWZoneHistory> gcwImperialScorePercentileHistoryThisGalaxy = new SWGMap<>(6, 4, StringType.ASCII);
+	private SWGMap<String, CurrentServerGCWZoneHistory> gcwGroupImperialScorePercentileHistoryThisGalaxy = new SWGMap<>(6, 5, StringType.ASCII);
+	private SWGMap<String, OtherServerGCWZonePercent> gcwImperialScorePercentileOtherGalaxies = new SWGMap<>(6, 6, StringType.ASCII);
+	private SWGMap<String, OtherServerGCWZonePercent> gcwGroupImperialScorePercentileOtherGalaxies = new SWGMap<>(6, 7, StringType.ASCII);
 	
 	public GuildObject(long objectId) {
 		super(objectId, BaselineType.GILD);
@@ -88,9 +92,50 @@ public class GuildObject extends SWGObject {
 		// unknown variable
 	}
 	
+	/**
+	 * Also indirectly sets rebel zone percent. If percentage is 70%, then imperials will have 70% control and rebels will have 30%.
+	 * @param terrain that the zone is located on. If {@code null}, no history is created.
+	 * @param zoneName name of zone to set percentage for
+	 * @param percentage amount that the imperials control this zone
+	 */
+	public void setImperialZonePercent(@Nullable Terrain terrain, @NotNull String zoneName, int percentage) {
+		CurrentServerGCWZonePercent oldServerGCWZonePercent = gcwImperialScorePercentileThisGalaxy.get(zoneName);
+		
+		if (oldServerGCWZonePercent != null) {
+			int oldPercentage = oldServerGCWZonePercent.percentage;
+			if (percentage == oldPercentage) {
+				// Percentage hasn't changed. Don't do anything.
+				return;
+			}
+			
+			// Insert historical data
+			if (terrain != null ){
+				setImperialZoneHistoricalPercent(zoneName, percentage);
+			}
+		}
+		
+		gcwImperialScorePercentileThisGalaxy.put(zoneName, new CurrentServerGCWZonePercent(percentage));
+		gcwImperialScorePercentileThisGalaxy.sendDeltaMessage(this);
+		gcwGroupImperialScorePercentileThisGalaxy.put(zoneName, new CurrentServerGCWZonePercent(percentage));
+		gcwGroupImperialScorePercentileThisGalaxy.sendDeltaMessage(this);
+	}
+	
+	private void setImperialZoneHistoricalPercent(@NotNull String zoneName, int percentage) {
+		int lastUpdateTime = (int) (System.currentTimeMillis() / 1000);
+		gcwImperialScorePercentileHistoryThisGalaxy.put(zoneName, new CurrentServerGCWZoneHistory(lastUpdateTime, percentage));
+		gcwImperialScorePercentileHistoryThisGalaxy.sendDeltaMessage(this);
+		gcwGroupImperialScorePercentileHistoryThisGalaxy.put(zoneName, new CurrentServerGCWZoneHistory(lastUpdateTime, percentage));
+		gcwGroupImperialScorePercentileHistoryThisGalaxy.sendDeltaMessage(this);
+		
+	}
+	
 	public static class CurrentServerGCWZonePercent implements Encodable {
 		
 		private int percentage = 0;
+		
+		public CurrentServerGCWZonePercent(int percentage) {
+			this.percentage = percentage;
+		}
 		
 		@Override
 		public byte [] encode() {
@@ -119,6 +164,11 @@ public class GuildObject extends SWGObject {
 		
 		private int lastUpdateTime = 0;
 		private int percentage = 0;
+		
+		public CurrentServerGCWZoneHistory(int lastUpdateTime, int percentage) {
+			this.lastUpdateTime = lastUpdateTime;
+			this.percentage = percentage;
+		}
 		
 		@Override
 		public byte [] encode() {

--- a/src/main/java/com/projectswg/holocore/resources/support/objects/swg/player/PlayerObject.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/swg/player/PlayerObject.java
@@ -159,6 +159,10 @@ public class PlayerObject extends IntangibleObject {
 		play3.toggleFlags(PlayerFlags.bitsetFromFlags(flags));
 	}
 	
+	public boolean isFlagSet(PlayerFlags flag) {
+		return play3.isFlagSet(flag.getFlag());
+	}
+	
 	public BitSet getProfileFlags() {
 		return play3.getProfileFlags();
 	}

--- a/src/main/java/com/projectswg/holocore/resources/support/objects/swg/player/PlayerObjectShared.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/swg/player/PlayerObjectShared.java
@@ -101,6 +101,10 @@ class PlayerObjectShared implements Persistable, MongoPersistable {
 		flagsList.sendDeltaMessage(obj);
 	}
 	
+	public boolean isFlagSet(int flag) {
+		return flagsList.get(flag);
+	}
+	
 	public BitSet getProfileFlags() {
 		return (BitSet) profileFlags.clone();
 	}

--- a/src/main/java/com/projectswg/holocore/services/gameplay/gcw/CivilWarRegionService.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/gcw/CivilWarRegionService.java
@@ -72,7 +72,7 @@ import java.util.stream.Collectors;
  */
 public class CivilWarRegionService extends Service {
 	
-	public static final long BASE_ZONE_POINTS = 50_000;	// Amount of points that each faction has by default in each zone. The point is to make a zone more difficult to capture if it has been reset.
+	private static final long BASE_ZONE_POINTS = 50_000;	// Amount of points that each faction has by default in each zone. The point is to make a zone more difficult to capture if it has been reset.
 	private static final String EGG_TEMPLATE = "object/tangible/spawning/shared_spawn_egg.iff";
 	private static final int PRESENCE_POINTS = 15;
 	
@@ -110,7 +110,7 @@ public class CivilWarRegionService extends Service {
 				ZoneMetadata zone = regionDatabase.getZone(regionName);
 				
 				if (zone == null) {
-					regionDatabase.createZone(regionName);
+					regionDatabase.createZone(regionName, BASE_ZONE_POINTS);
 					guildObject.setImperialZonePercent(null, regionName, 50);	// Start the zone as perfectly balanced. You know, as all things should be.
 				} else {
 					int imperialPercentage = calculateImperialPercent(zone.getImperialPoints(), zone.getRebelPoints());
@@ -276,7 +276,7 @@ public class CivilWarRegionService extends Service {
 			
 			if (rebels <= 0) {
 				// No rebels present. Deduct points.
-				rebelPoints =  Math.min(zoneMetadata.getRebelPoints() - PRESENCE_POINTS, BASE_ZONE_POINTS);
+				rebelPoints =  Math.max(zoneMetadata.getRebelPoints() - PRESENCE_POINTS, BASE_ZONE_POINTS);
 				
 				regionDatabase.setRebelPoints(zoneName, rebelPoints);
 			} else {
@@ -291,7 +291,7 @@ public class CivilWarRegionService extends Service {
 			
 			if (imperials <= 0) {
 				// No imperials present. Deduct points.
-				imperialPoints =  Math.min(zoneMetadata.getImperialPoints() - PRESENCE_POINTS, BASE_ZONE_POINTS);
+				imperialPoints =  Math.max(zoneMetadata.getImperialPoints() - PRESENCE_POINTS, BASE_ZONE_POINTS);
 				
 				regionDatabase.setImperialPoints(zoneName, imperialPoints);
 			} else {

--- a/src/main/java/com/projectswg/holocore/services/gameplay/gcw/CivilWarRegionService.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/gcw/CivilWarRegionService.java
@@ -1,0 +1,322 @@
+/***********************************************************************************
+ * Copyright (c) 2018 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.services.gameplay.gcw;
+
+import com.projectswg.common.data.encodables.gcw.GcwGroup;
+import com.projectswg.common.data.encodables.gcw.GcwGroupZone;
+import com.projectswg.common.data.encodables.gcw.GcwRegion;
+import com.projectswg.common.data.encodables.gcw.GcwRegionZone;
+import com.projectswg.common.data.encodables.tangible.Posture;
+import com.projectswg.common.data.encodables.tangible.PvpFaction;
+import com.projectswg.common.data.encodables.tangible.PvpFlag;
+import com.projectswg.common.data.location.Location;
+import com.projectswg.common.data.location.Terrain;
+import com.projectswg.common.data.objects.GameObjectType;
+import com.projectswg.common.network.packets.SWGPacket;
+import com.projectswg.common.network.packets.swg.zone.GcwGroupsRsp;
+import com.projectswg.common.network.packets.swg.zone.GcwRegionsReq;
+import com.projectswg.common.network.packets.swg.zone.GcwRegionsRsp;
+import com.projectswg.holocore.intents.gameplay.gcw.faction.CivilWarPointIntent;
+import com.projectswg.holocore.intents.support.global.network.InboundPacketIntent;
+import com.projectswg.holocore.intents.support.objects.swg.ObjectCreatedIntent;
+import com.projectswg.holocore.resources.support.data.server_info.loader.GcwRegionLoader;
+import com.projectswg.holocore.resources.support.data.server_info.loader.ServerData;
+import com.projectswg.holocore.resources.support.data.server_info.mongodb.PswgDatabase;
+import com.projectswg.holocore.resources.support.data.server_info.mongodb.PswgGcwRegionDatabase;
+import com.projectswg.holocore.resources.support.data.server_info.mongodb.ZoneMetadata;
+import com.projectswg.holocore.resources.support.global.player.Player;
+import com.projectswg.holocore.resources.support.global.player.PlayerFlags;
+import com.projectswg.holocore.resources.support.objects.ObjectCreator;
+import com.projectswg.holocore.resources.support.objects.swg.SWGObject;
+import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject;
+import com.projectswg.holocore.resources.support.objects.swg.guild.GuildObject;
+import com.projectswg.holocore.resources.support.objects.swg.player.PlayerObject;
+import me.joshlarson.jlcommon.concurrency.ScheduledThreadPool;
+import me.joshlarson.jlcommon.control.IntentHandler;
+import me.joshlarson.jlcommon.control.Service;
+import me.joshlarson.jlcommon.log.Log;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Responsibilities:
+ * <ul>
+ *     <li>Showing regions on the planetary map</li>
+ *     <li>Keeping track of who has the most control of a region</li>
+ * </ul>
+ */
+public class CivilWarRegionService extends Service {
+	
+	private static final String EGG_TEMPLATE = "object/tangible/spawning/shared_spawn_egg.iff";
+	
+	private final GcwRegionLoader regionLoader;	// Stores static information about zone names and their locations in the game
+	private final PswgGcwRegionDatabase regionDatabase;	// Stores dynamic information about how many points each faction has per zone
+	private final ScheduledThreadPool executor;
+	private final Collection<SWGObject> eggs;
+	
+	private GuildObject guildObject;
+	
+	public CivilWarRegionService() {
+		regionLoader = ServerData.INSTANCE.getGcwRegionLoader();
+		regionDatabase = PswgDatabase.INSTANCE.getGcwRegions();
+		executor = new ScheduledThreadPool(1, "civil-war-region-service");
+		eggs = Collections.synchronizedCollection(new ArrayList<>());
+	}
+	
+	@Override
+	public boolean start() {
+		boolean startable = super.start() && guildObject != null;
+		
+		if (!startable) {
+			return false;
+		}
+		
+		Map<Terrain, Collection<GcwRegionLoader.GcwRegionInfo>> regionsByTerrain = regionLoader.getRegionsByTerrain();
+		
+		for (Map.Entry<Terrain, Collection<GcwRegionLoader.GcwRegionInfo>> terrainCollectionEntry : regionsByTerrain.entrySet()) {
+			Terrain terrain = terrainCollectionEntry.getKey();
+			Collection<GcwRegionLoader.GcwRegionInfo> terrainRegions = terrainCollectionEntry.getValue();
+			
+			for (GcwRegionLoader.GcwRegionInfo terrainRegion : terrainRegions) {
+				String regionName = terrainRegion.getRegionName();
+				
+				ZoneMetadata zone = regionDatabase.getZone(regionName);
+				
+				if (zone == null) {
+					regionDatabase.createZone(regionName);
+					guildObject.setImperialZonePercent(null, regionName, 50);	// Start the zone as perfectly balanced. You know, as all things should be.
+				} else {
+					int imperialPercentage = calculateImperialPercent(zone.getImperialPoints(), zone.getRebelPoints());
+					guildObject.setImperialZonePercent(null, regionName, imperialPercentage);
+				}
+				
+				SWGObject egg = ObjectCreator.createObjectFromTemplate(EGG_TEMPLATE);
+				Location location = Location.builder()
+						.setTerrain(terrain)
+						.setX(terrainRegion.getCenterX())
+						.setY(0)	// TODO read height of terrain and use that as y-coordinate
+						.setZ(terrainRegion.getCenterZ())
+						.build();
+				
+				egg.moveToContainer(null, location);	// Spawn egg at desired position
+				ObjectCreatedIntent.broadcast(egg);
+				eggs.add(egg);
+			}
+		}
+		
+		long checkRate = 1000;	// Attempt to delete old NPCs every 1000ms
+		executor.start();
+		executor.executeWithFixedRate(checkRate, checkRate, this::grantPresencePoints);
+		
+		return true;
+	}
+	
+	@IntentHandler
+	private void handleObjectCreated(ObjectCreatedIntent intent) {
+		SWGObject genericObject = intent.getObject();
+		
+		if (genericObject.getGameObjectType() == GameObjectType.GOT_GUILD) {
+			guildObject = (GuildObject) genericObject;
+		}
+	}
+	
+	/**
+	 * Handles showing GCW zones to the player.
+	 */
+	@IntentHandler
+	private void handleInboundPacket(InboundPacketIntent intent) {
+		Player player = intent.getPlayer();
+		SWGPacket packet = intent.getPacket();
+		
+		if (!(packet instanceof GcwRegionsReq)) {
+			return;
+		}
+		
+		Map<Terrain, Collection<GcwRegionLoader.GcwRegionInfo>> regionsByTerrain = regionLoader.getRegionsByTerrain();
+		Collection<GcwRegion> clientRegions = new ArrayList<>();
+		Collection<GcwGroup> clientGroups = new ArrayList<>();
+		
+		for (Map.Entry<Terrain, Collection<GcwRegionLoader.GcwRegionInfo>> regionInfoEntry : regionsByTerrain.entrySet()) {
+			Terrain terrain = regionInfoEntry.getKey();
+			Collection<GcwRegionLoader.GcwRegionInfo> serverRegions = regionInfoEntry.getValue();
+			
+			Collection<GcwRegionZone> clientRegionZones = serverRegions.stream()
+					.map(info -> new GcwRegionZone(info.getRegionName(), info.getCenterX(), info.getCenterZ(), info.getRadius()))
+					.collect(Collectors.toList());
+			
+			Collection<GcwGroupZone> clientGroupZones = serverRegions.stream()
+					.map(info -> new GcwGroupZone(info.getRegionName(), 0))
+					.collect(Collectors.toList());
+			
+			GcwRegion clientRegion = new GcwRegion(terrain.getName(), clientRegionZones);
+			clientRegions.add(clientRegion);
+			
+			GcwGroup clientGroup = new GcwGroup(terrain.getName(), clientGroupZones);
+			clientGroups.add(clientGroup);
+		}
+		
+		player.sendPacket(
+				new GcwRegionsRsp(clientRegions),	// Show GCW regions below the category "Galactic Civil War Contested Zone" in the Locations portion of the planetary map
+				new GcwGroupsRsp(clientGroups)	// Show GCW regions as Locations on the map portion of the planetary map
+		);
+	}
+	
+	/**
+	 * Counts points towards the relevant faction if the points were awarded inside a region
+	 */
+	@IntentHandler
+	private void handleCivilWarPoint(CivilWarPointIntent intent) {
+		PlayerObject player = intent.getReceiver();
+		CreatureObject creature = (CreatureObject) player.getParent();
+		PvpFaction pvpFaction = creature.getPvpFaction();
+		
+		Objects.requireNonNull(creature, "PlayerObject without a parent");
+		
+		if (pvpFaction == PvpFaction.NEUTRAL) {
+			// Not sure how a neutral would receive GCW points, but that shouldn't tip the scales in either direction
+			return;
+		}
+		
+		
+		int points = intent.getPoints();
+		Optional<GcwRegionLoader.GcwRegionInfo> regionInfoOptional = regionLoader.getRegion(creature);
+		
+		if (regionInfoOptional.isEmpty()) {
+			// Player didn't receive GCW points inside a region
+			return;
+		}
+		
+		GcwRegionLoader.GcwRegionInfo regionInfo = regionInfoOptional.get();
+		String zoneName = regionInfo.getRegionName();
+		
+		ZoneMetadata zoneMetadata = regionDatabase.getZone(zoneName);
+		
+		if (zoneMetadata == null) {
+			Log.w("Synchronization issue between SDB file and database, unable to find zone %s", zoneName);
+			return;
+		}
+		
+		long rebelTotal = zoneMetadata.getRebelPoints();
+		long imperialTotal = zoneMetadata.getImperialPoints();
+		
+		switch (pvpFaction) {
+			case REBEL: {
+				rebelTotal += points;
+				regionDatabase.addRebelPoints(zoneName, rebelTotal);
+				break;
+			}
+			case IMPERIAL: {
+				imperialTotal += points;
+				regionDatabase.addImperialPoints(zoneName, imperialTotal);
+				break;
+			}
+		}
+		
+		int imperialPercent = calculateImperialPercent(imperialTotal, rebelTotal);
+		guildObject.setImperialZonePercent(regionInfo.getTerrain(), zoneName, imperialPercent);
+	}
+	
+	private void grantPresencePoints() {
+		for (SWGObject egg : eggs) {
+			Set<Player> observers = egg.getObservers();
+			
+			for (Player observer : observers) {
+				CreatureObject creatureObject = observer.getCreatureObject();
+				PvpFaction pvpFaction = creatureObject.getPvpFaction();
+				
+				boolean incapacitated = creatureObject.getPosture() == Posture.INCAPACITATED;
+				boolean dead = creatureObject.getPosture() == Posture.DEAD;
+				boolean cloaked = !creatureObject.isVisible();
+				boolean notSpecialForces = !creatureObject.hasPvpFlag(PvpFlag.OVERT);
+				boolean afk = creatureObject.getPlayerObject().isFlagSet(PlayerFlags.AFK);
+				boolean offline = creatureObject.getPlayerObject().isFlagSet(PlayerFlags.LD);
+				
+				if (incapacitated || dead || cloaked || notSpecialForces || afk || offline) {
+					// Player must participate in GCW. Being present is not enough.
+					return;
+				}
+				
+				// TODO how do we know that they've been in the area an appropriate amount of time?
+			}
+		}
+	}
+	
+	private void decayPresencePoints() {
+		for (SWGObject egg : eggs) {
+			Set<Player> observers = egg.getObservers();
+			
+			long rebels = observers.stream()
+					.map(Player::getCreatureObject)
+					.filter(creatureObject -> creatureObject.hasPvpFlag(PvpFlag.OVERT))	// Only Special Forces players can prevent decay
+					.filter(creatureObject -> {
+						PlayerObject playerObject = creatureObject.getPlayerObject();
+						boolean afk = playerObject.isFlagSet(PlayerFlags.AFK);
+						boolean offline = playerObject.isFlagSet(PlayerFlags.LD);
+						boolean incapacitated = creatureObject.getPosture() == Posture.INCAPACITATED;
+						boolean dead = creatureObject.getPosture() == Posture.DEAD;
+						boolean cloaked = !creatureObject.isVisible();
+						boolean specialForces = creatureObject.hasPvpFlag(PvpFlag.OVERT);	// TODO separate filter
+						
+						return !afk && !offline && !incapacitated && !dead && !cloaked && specialForces;
+					})
+					.map(CreatureObject::getPvpFaction)
+					.filter(faction -> faction == PvpFaction.REBEL)
+					.count();
+
+			if (rebels <= 0) {
+				// No rebels present. Deduct points.
+				
+			}
+			
+			long imperials = observers.stream()
+					.map(Player::getCreatureObject)
+					.map(CreatureObject::getPvpFaction)
+					.filter(faction -> faction == PvpFaction.IMPERIAL)
+					.count();
+			
+			if (imperials <= 0) {
+				// No imperials present. Deduct points.
+				
+			}
+		}
+	}
+	
+	private int calculateImperialPercent(long imperialTotal, long rebelTotal) {
+		long sum = imperialTotal + rebelTotal;
+		
+		if (sum <= 0) {
+			return 50;	// Return to 50/50 in case things are about to go horribly wrong
+		}
+		
+		return (int) ((double) imperialTotal / (double) (imperialTotal + rebelTotal) * 100);
+	}
+	
+	// TODO scheduled job that deducts points from factions that are not present in all zones, until the base amount of 50_000 is reached
+	
+	// TODO scheduled job that checks legitimate factional presence inside each zone. This will count towards points in that zone for the relevant faction.
+}

--- a/src/main/java/com/projectswg/holocore/services/gameplay/gcw/GalacticCivilWarManager.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/gcw/GalacticCivilWarManager.java
@@ -7,6 +7,7 @@ import me.joshlarson.jlcommon.control.ManagerStructure;
 		CivilWarPointService.class,
 		CivilWarPvpService.class,
 		CivilWarRankService.class,
+		CivilWarRegionService.class,
 })
 public class GalacticCivilWarManager extends Manager {
 	

--- a/src/main/java/com/projectswg/holocore/services/gameplay/player/PlayerManager.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/player/PlayerManager.java
@@ -5,6 +5,7 @@ import com.projectswg.holocore.services.gameplay.player.collections.CollectionMa
 import com.projectswg.holocore.services.gameplay.player.equipment.EquipmentManager;
 import com.projectswg.holocore.services.gameplay.player.experience.ExperienceManager;
 import com.projectswg.holocore.services.gameplay.player.group.GroupManager;
+import com.projectswg.holocore.services.gameplay.player.guild.GuildService;
 import me.joshlarson.jlcommon.control.Manager;
 import me.joshlarson.jlcommon.control.ManagerStructure;
 
@@ -13,7 +14,8 @@ import me.joshlarson.jlcommon.control.ManagerStructure;
 		CollectionManager.class,
 		EquipmentManager.class,
 		ExperienceManager.class,
-		GroupManager.class
+		GroupManager.class,
+		GuildService.class,
 })
 public class PlayerManager extends Manager {
 	

--- a/src/main/java/com/projectswg/holocore/services/gameplay/player/guild/GuildService.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/player/guild/GuildService.java
@@ -1,0 +1,63 @@
+package com.projectswg.holocore.services.gameplay.player.guild;
+
+import com.projectswg.common.data.objects.GameObjectType;
+import com.projectswg.holocore.intents.support.global.zone.PlayerEventIntent;
+import com.projectswg.holocore.intents.support.objects.swg.ObjectCreatedIntent;
+import com.projectswg.holocore.resources.support.global.player.PlayerEvent;
+import com.projectswg.holocore.resources.support.objects.ObjectCreator;
+import com.projectswg.holocore.resources.support.objects.awareness.AwarenessType;
+import com.projectswg.holocore.resources.support.objects.swg.SWGObject;
+import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject;
+import com.projectswg.holocore.resources.support.objects.swg.guild.GuildObject;
+import me.joshlarson.jlcommon.control.IntentHandler;
+import me.joshlarson.jlcommon.control.Service;
+
+import java.util.List;
+
+/**
+ * Responsibilities:
+ * <ol>
+ *     <li>Ensures existence of a singleton {@link GuildObject}</li>
+ *     <li>Ensures every player is made aware of the {@link GuildObject}</li>
+ * </ol>
+ */
+public class GuildService extends Service {
+	
+	private GuildObject guildObject;
+	
+	public GuildService() {
+	
+	}
+	
+	@Override
+	public boolean initialize() {
+		if (guildObject == null) {
+			// A guild object doesn't already exist. Let's create one.
+			guildObject = (GuildObject) ObjectCreator.createObjectFromTemplate("object/guild/shared_guild_object.iff");
+			ObjectCreatedIntent.broadcast(guildObject);
+		}
+		
+		return super.start();
+	}
+	
+	@IntentHandler
+	private void handleObjectCreated(ObjectCreatedIntent intent) {
+		SWGObject genericObject = intent.getObject();
+		
+		if (genericObject.getGameObjectType() == GameObjectType.GOT_GUILD) {
+			guildObject = (GuildObject) genericObject;
+		}
+	}
+	
+	/**
+	 * Every player should be aware of the GuildObject in order for guilds and, oddly enough, GCW regions.to work
+	 */
+	@IntentHandler
+	private void handlePlayerEvent(PlayerEventIntent intent) {
+		if (PlayerEvent.PE_ZONE_IN_SERVER == intent.getEvent()) {
+			CreatureObject creature = intent.getPlayer().getCreatureObject();
+			
+			creature.setAware(AwarenessType.GUILD, List.of(guildObject));
+		}
+	}
+}

--- a/src/test/java/com/projectswg/holocore/resources/gameplay/player/TestActivePlayerPredicate.java
+++ b/src/test/java/com/projectswg/holocore/resources/gameplay/player/TestActivePlayerPredicate.java
@@ -1,0 +1,80 @@
+package com.projectswg.holocore.resources.gameplay.player;
+
+import com.projectswg.common.data.encodables.tangible.Posture;
+import com.projectswg.holocore.resources.support.global.player.Player;
+import com.projectswg.holocore.resources.support.global.player.PlayerFlags;
+import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject;
+import com.projectswg.holocore.resources.support.objects.swg.player.PlayerObject;
+import com.projectswg.holocore.test.resources.GenericCreatureObject;
+import com.projectswg.holocore.test.resources.GenericPlayer;
+import com.projectswg.holocore.test.runners.TestRunnerSynchronousIntents;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public class TestActivePlayerPredicate extends TestRunnerSynchronousIntents {
+	
+	private final ActivePlayerPredicate predicate;
+	
+	public TestActivePlayerPredicate() {
+		predicate = new ActivePlayerPredicate();
+	}
+	
+	private Player player;
+	private CreatureObject creatureObject;
+	private PlayerObject playerObject;
+	
+	@Before
+	public void setup() {
+		player = new GenericPlayer();
+		creatureObject = new GenericCreatureObject(1);
+		playerObject = creatureObject.getPlayerObject();
+		player.setCreatureObject(creatureObject);
+	}
+	
+	@Test
+	public void testAfk() {
+		playerObject.setFlag(PlayerFlags.AFK);
+		
+		boolean actual = predicate.test(player);
+		
+		assertFalse("AFK players should not be determined active", actual);
+	}
+	
+	@Test
+	public void testOffline() {
+		playerObject.setFlag(PlayerFlags.LD);
+		
+		boolean actual = predicate.test(player);
+		
+		assertFalse("LD players should not be determined active", actual);
+	}
+	
+	@Test
+	public void testIncapacitated() {
+		creatureObject.setPosture(Posture.INCAPACITATED);
+		
+		boolean actual = predicate.test(player);
+		
+		assertFalse("Incapacitated players should not be determined active", actual);
+	}
+	
+	@Test
+	public void testDead() {
+		creatureObject.setPosture(Posture.DEAD);
+		
+		boolean actual = predicate.test(player);
+		
+		assertFalse("Dead players should not be determined active", actual);
+	}
+	
+	@Test
+	public void testCloaked() {
+		creatureObject.setVisible(false);
+		
+		boolean actual = predicate.test(player);
+		
+		assertFalse("Cloaked players should not be determined active", actual);
+	}
+}


### PR DESCRIPTION
- Creation of regions through the sdb.
- Display regions in-game.
- Data on regions is persisted.
- Every 15 minutes presence is detected and factions are rewarded or punished for not being present.
- GCW points earned inside zones count towards percentage. Points earned outside or in space do not (yet) count.
- The GCW window isn't working 100%, but at least it doesn't crash the client anymore.