### PR TITLE
Exotic mods from equipment are granted to the player when equipped

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/gameplay/player/experience/skills/skillmod/SkillModService.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/player/experience/skills/skillmod/SkillModService.java
@@ -112,7 +112,7 @@ public class SkillModService extends Service {
 		CreatureObject creature = cti.getObject().getOwner().getCreatureObject();
 	
 		for (Map.Entry<String, String> attributes : cti.getObject().getAttributes().entrySet()){
-			if(attributes.getKey().endsWith("_modified")){
+			if(attributes.getKey().startsWith("cat_stat_mod_bonus") || attributes.getKey().startsWith("cat_skill_mod_bonus")){
 				String[] splitModName = attributes.getKey().split(":",2);
 				String modName = splitModName[1];
 				int modValue = Integer.parseInt(attributes.getValue());


### PR DESCRIPTION
Problem was that names of exotic mods don't end with _modified.
Now it just looks at anything that's under the Stat bonus or Skillmod bonus categories, which would naturally be statmods and skillmods.