### PR TITLE
Updated readme with JDK 9 -> 13 and MongoDB instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 ![Banner](https://imgur.com/V14kDE5.png)
 
 ![License](https://img.shields.io/badge/license-GPLv3-blue.svg?longCache=true&style=flat)
-![JDK](https://img.shields.io/badge/JDK-9-blue.svg?longCache=true&style=flat)
+![JDK](https://img.shields.io/badge/JDK-13-blue.svg?longCache=true&style=flat)
 ![Discord](https://img.shields.io/discord/373548910225915905.svg)
-![Bitbucket open pull requests](https://img.shields.io/bitbucket/pr/projectswg/holocore.svg)
 
 # Introduction #
 
@@ -22,18 +21,14 @@ You can find detailed information on the [wiki](https://bitbucket.org/projectswg
 
 Ready to help bring back an awesome MMORPG with your programming skills?
 
-The following assumes that you're familiar with:
-
-* Installing applications on your machine
-* Command line interfaces
-* VCSs, Git in particular
-* Programming in general
-
 ## Java Development Kit ##
 
 In order to compile the source code, you need a JDK installation on your machine. The `JAVA_HOME` environment variable
-should point to the directory of the JDK! It should be version 9 as minimum. You can see your installed Java version
+should point to the directory of the JDK! It should be version 13 as minimum. You can see your installed Java version
 by running `java -version`.
+
+## Submodules ##
+The project uses submodules. Get them by running: git submodule update --init
 
 ## Clientdata ##
 
@@ -79,36 +74,15 @@ holocore/
 	...
 ```
 
-## Gradle ##
+## MongoDB ##
+User information is read from a MongoDB database that can be run on any machine on your network. Default is the machine that Holocore is running on.
 
-This project uses Gradle as its build tool of choice. You must install Gradle on your machine in order to build the
-source code.
+1. Create database: use nge
+2. Create a user for Holocore: `db.createUser({user: "holocore", pwd: "pass", roles: []})`
+3. Create your game user: `db.users.insert({username: "user", password: "pass", accessLevel: "dev", banned: false, characters: []})`
 
-Compile and run Holocores unit tests using Gradle: `gradle test --info` (Might fail if you haven't extracted clientdata yet)
-Compile and run Holocores main code using Gradle: `gradle run`
+## Running Holocore ##
+Compile and run Holocores main code using Gradle: `./gradlew run`
 
-## Forwarder ##
-
-Holocore uses TCP for network communications, whereas SWG was programmed for UDP.  This adds numerous efficiencies with
-long distance communications, but requires that a little more work is done on the client side.  If you are using the
-launcher, you do not have to worry about this.  If you are not using the launcher, follow the guide
-[here](https://bitbucket.org/projectswg/forwarder).
-
-## Credentials ##
-
-Default credentials are currently created. Your username is `holocore` and your password is `password`. This user has the
-highest admin level assigned to it.
-
-## Contributing ##
-
-1. Fork this repository
-2. Clone the fork you just created, using `git clone`
-3. Get the submodules using `git submodule update --init`
-4. Find something to do in our issues list that is unassigned => https://bitbucket.org/projectswg/holocore/issues?status=new&status=open
-5. Create a new branch on your fork of holocore
-6. Write code, commit and push it to your branch
-7. Once ready, create a pull request with destination branch `quality_assurance` and source branch
-`<your_branch_name>`
-8. Your changes are reviewed and are merged, unless something is wrong
-9. Once merged, your changes will be available in future builds
-10. If you want to work on something else, go back to step 4
+## Running automated tests ##
+Compile and run Holocores unit tests using Gradle: `./gradlew test --info`


### PR DESCRIPTION
Also detailed that we don't need people to install Gradle anymore, just use the wrapper.