### PR TITLE
Combat log now displays actual amount healed instead of theoretical max #257

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandHeal.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandHeal.java
@@ -136,7 +136,7 @@ enum CombatCommandHeal implements CombatCommandHitType {
 				healed.modifyHealth(healAmount);
 				difference = healed.getHealth() - currentHealth;
 				attribName = "HEALTH";
-				healed.sendObservers(createCombatSpam(healer, healed, healAmount));
+				healed.sendObservers(createCombatSpam(healer, healed, difference));
 				break;
 			}
 			
@@ -177,7 +177,7 @@ enum CombatCommandHeal implements CombatCommandHitType {
 		healed.sendObservers(combatAction, flyText, effect);
 	}
 
-	private static CombatSpam createCombatSpam(CreatureObject healer, CreatureObject healed, int healAmount) {
+	private static CombatSpam createCombatSpam(CreatureObject healer, CreatureObject healed, int difference) {
 		CombatSpam spam = new CombatSpam(healer.getObjectId());
 		
 		spam.setAttacker(healer.getObjectId());
@@ -186,7 +186,7 @@ enum CombatCommandHeal implements CombatCommandHitType {
 		spam.setDefenderPosition(healed.getLocation().getPosition());
 		spam.setInfo(new AttackInfo());
 		spam.setDataType((byte) 2);	// 2 means the combat log entry is a specified message
-		OutOfBandPackage oobp = new OutOfBandPackage(new ProsePackage("StringId", new StringId("healing", "perform_heal_damage_success"), "TT", healer.getObjectName(), "TO", healed.getObjectName(), "DI", healAmount));
+		OutOfBandPackage oobp = new OutOfBandPackage(new ProsePackage("StringId", new StringId("healing", "perform_heal_damage_success"), "TT", healer.getObjectName(), "TO", healed.getObjectName(), "DI", difference));
 		spam.setSpamMessage(oobp);
 		spam.setSpamType(CombatSpamType.MEDICAL);
 		


### PR DESCRIPTION
Implementation of #257 

Simply display `difference` in the combat log, which is also what the flytext shows.