### PR TITLE
The /setExperience hint now specifies that a target parameter is required

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/global/commands/callbacks/admin/CmdSetExperience.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/global/commands/callbacks/admin/CmdSetExperience.java
@@ -29,8 +29,10 @@ package com.projectswg.holocore.resources.support.global.commands.callbacks.admi
 import com.projectswg.holocore.intents.gameplay.player.experience.ExperienceIntent;
 import com.projectswg.holocore.intents.support.global.chat.SystemMessageIntent;
 import com.projectswg.holocore.resources.support.global.commands.ICmdCallback;
+import com.projectswg.holocore.resources.support.global.player.AccessLevel;
 import com.projectswg.holocore.resources.support.global.player.Player;
 import com.projectswg.holocore.resources.support.objects.swg.SWGObject;
+import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject;
 import me.joshlarson.jlcommon.log.Log;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -40,19 +42,31 @@ public class CmdSetExperience implements ICmdCallback {
 	public void execute(@NotNull Player player, @Nullable SWGObject target, @NotNull String args) {
 		String[] argArray = args.split(" ");
 		
-		if (argArray.length != 2) {
-			SystemMessageIntent.broadcastPersonal(player, "Expected format: /setExperience <xpType> <xpGained>");
+		if (player.getAccessLevel() == AccessLevel.PLAYER) {
+			SystemMessageIntent.broadcastPersonal(player, "This command can only be used by admins");
 			return;
 		}
+		
+		if (argArray.length != 2) {
+			SystemMessageIntent.broadcastPersonal(player, "Expected format: /setExperience <target> <xpType> <xpGained>");
+			return;
+		}
+		
+		if (!(target instanceof CreatureObject)) {
+			SystemMessageIntent.broadcastPersonal(player, "The command must have a creature as a target");
+			return;
+		}
+		
+		CreatureObject creature = (CreatureObject) target;
 		
 		String xpType = argArray[0];
 		String xpGainedRaw = argArray[1];
 		
 		try {
-			int xpGained = Integer.valueOf(xpGainedRaw);
-			new ExperienceIntent(player.getCreatureObject(), xpType, xpGained).broadcast();
+			int xpGained = Integer.parseInt(xpGainedRaw);
+			new ExperienceIntent(creature, xpType, xpGained).broadcast();
 			
-			Log.i("XP command: %s gave themselves %d %s XP", player.getUsername(), xpGained, xpType);
+			Log.i("XP command: %s gave %s %d %s XP", player, target, xpGained, xpType);
 		} catch (NumberFormatException e) {
 			SystemMessageIntent.broadcastPersonal(player, String.format("XP command: %s is not a number", xpGainedRaw));
 			


### PR DESCRIPTION
`/setExperience` requires a target. It's a client side thing.

`/setExperience me combat 5000` will work.
`/setExperience combat 5000` won't work. This is what the help text currently suggests is the correct form, but it's actually missing the target parameter.