### PR TITLE
Fixed issue where NPCs didn't face the target properly when attacking

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/npc/ai/NpcCombatMode.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/npc/ai/NpcCombatMode.kt
@@ -120,7 +120,8 @@ class NpcCombatMode(obj: AIObject) : NpcMode(obj) {
 		// If we're close, angle towards target
 		val myLocation = obj.location
 		val targetLocation = target.location
-		MoveObjectIntent.broadcast(obj, obj.parent, Location.builder(myLocation).setHeading(myLocation.getHeadingTo(targetLocation)).build(), npcRunSpeed)
+		val headingTo = myLocation.getHeadingTo(targetLocation.position)
+		MoveObjectIntent.broadcast(obj, obj.parent, Location.builder(myLocation).setHeading(headingTo).build(), npcRunSpeed)
 		
 		if (target.posture == Posture.INCAPACITATED) {
 			QueueCommandIntent.broadcast(obj, target, "", DataLoader.commands().getCommand("deathblow"), 0)


### PR DESCRIPTION
Fixes #111 

Seems getting a heading from a `Location` to another `Location` is calculated differently than from a `Location` to a `Point3D`.
This simply switches calculation methods, as the `Point3D` variant seems to do what we want.