### PR TITLE
Fixed static item weapon proc effect not displaying a proper text

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/objects/StaticItemCreator.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/StaticItemCreator.kt
@@ -35,7 +35,6 @@ import com.projectswg.holocore.resources.support.objects.swg.tangible.TangibleOb
 import com.projectswg.holocore.resources.support.objects.swg.weapon.WeaponObject
 import com.projectswg.holocore.services.gameplay.jedi.LightsaberCrystalService
 import java.util.*
-import kotlin.math.floor
 
 object StaticItemCreator {
 	
@@ -150,7 +149,7 @@ object StaticItemCreator {
 		
 		if (info.procEffect.isNotEmpty())
 		// Not all weapons have a proc effect
-			obj.addAttribute("proc_name", info.procEffect)
+			obj.addAttribute("proc_name", "@ui_buff:${info.procEffect}")
 		
 		// TODO set DPS
 		


### PR DESCRIPTION
Effect Name before
![image](https://user-images.githubusercontent.com/4640241/100526254-60f73a00-31c7-11eb-9242-c6b75365dbc5.png)

Effect Name after
![image](https://user-images.githubusercontent.com/4640241/100526237-3d33f400-31c7-11eb-851e-203add565c94.png)
