### PR TITLE
Fix error in ConversationService when spawning a NPC using /createNPC

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/npc/spawn/Spawner.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/npc/spawn/Spawner.kt
@@ -127,7 +127,7 @@ class Spawner(spawn: SpawnInfo, egg: SWGObject) {
 	val maxLevel: Int
 		get() = spawn.maxLevel
 
-	val conversationId: String
+	val conversationId: String?
 		get() = spawn.conversationId
 
 	val name: String

--- a/src/main/java/com/projectswg/holocore/services/gameplay/conversation/ConversationService.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/conversation/ConversationService.java
@@ -140,6 +140,10 @@ public class ConversationService extends Service {
 		Spawner spawner = npc.getSpawner();
 		String conversationId = spawner.getConversationId();
 		
+		if (conversationId == null) {
+			return;
+		}
+		
 		List<Conversation> conversations = conversationLoader.getInitialConversations(conversationId);
 		
 		Conversation conversation = reduce(conversations, starter.getOwner());
@@ -195,6 +199,10 @@ public class ConversationService extends Service {
 		ConversationLoader conversationLoader = ServerData.INSTANCE.getConversationLoader();
 		Spawner spawner = npc.getSpawner();
 		String conversationId = spawner.getConversationId();
+		
+		if (conversationId == null) {
+			return false;
+		}
 		
 		Collection<String> spawnConversationIds = conversationLoader.getConversationIds(conversationId);
 		


### PR DESCRIPTION
Problem is that the spawninfos sometimes have a null conversation ID which isn't allowed by `Spawner`.

Relevant log:

```
10-01-21 03:23:12.164 T: [CommandQueueService] Ziggy/Jobut Veah executed command createnpc
10-01-21 03:23:12.166 E: Fatal Exception while processing intent: ObjectCreatedIntent
10-01-21 03:23:12.166 E: Exception in thread "intent-processor-5" java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
10-01-21 03:23:12.166 E: Caused by: java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
10-01-21 03:23:12.166 E:     me.joshlarson.jlcommon/me.joshlarson.jlcommon.control.Service.invoke(Service.java:135)
10-01-21 03:23:12.166 E:     me.joshlarson.jlcommon/me.joshlarson.jlcommon.control.Service.lambda$registerIntentHandlers$1(Service.java:119)
10-01-21 03:23:12.166 E:     me.joshlarson.jlcommon/me.joshlarson.jlcommon.control.IntentManager$IntentRunner.broadcast(IntentManager.java:214)
10-01-21 03:23:12.166 E:     me.joshlarson.jlcommon/me.joshlarson.jlcommon.control.IntentManager$IntentExecutor.run(IntentManager.java:269)
10-01-21 03:23:12.166 E:     me.joshlarson.jlcommon/me.joshlarson.jlcommon.utilities.ThreadUtilities.safeRun(ThreadUtilities.java:47)
10-01-21 03:23:12.166 E:     me.joshlarson.jlcommon/me.joshlarson.jlcommon.concurrency.ThreadPool$ThreadExecutor.threadExecutor(ThreadPool.java:174)
10-01-21 03:23:12.166 E:     java.base/java.lang.Thread.run(Thread.java:830)
10-01-21 03:23:12.166 E:   Exception in thread "intent-processor-5" java.lang.reflect.InvocationTargetException: null
10-01-21 03:23:12.166 E:   Caused by: java.lang.reflect.InvocationTargetException: null
10-01-21 03:23:12.167 E:       jdk.internal.reflect.GeneratedMethodAccessor21.invoke(Unknown Source)
10-01-21 03:23:12.167 E:       java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
10-01-21 03:23:12.167 E:       java.base/java.lang.reflect.Method.invoke(Method.java:567)
10-01-21 03:23:12.167 E:       me.joshlarson.jlcommon/me.joshlarson.jlcommon.control.Service.invoke(Service.java:133)
10-01-21 03:23:12.167 E:       me.joshlarson.jlcommon/me.joshlarson.jlcommon.control.Service.lambda$registerIntentHandlers$1(Service.java:119)
10-01-21 03:23:12.167 E:       me.joshlarson.jlcommon/me.joshlarson.jlcommon.control.IntentManager$IntentRunner.broadcast(IntentManager.java:214)
10-01-21 03:23:12.167 E:       me.joshlarson.jlcommon/me.joshlarson.jlcommon.control.IntentManager$IntentExecutor.run(IntentManager.java:269)
10-01-21 03:23:12.167 E:       me.joshlarson.jlcommon/me.joshlarson.jlcommon.utilities.ThreadUtilities.safeRun(ThreadUtilities.java:47)
10-01-21 03:23:12.167 E:       me.joshlarson.jlcommon/me.joshlarson.jlcommon.concurrency.ThreadPool$ThreadExecutor.threadExecutor(ThreadPool.java:174)
10-01-21 03:23:12.167 E:       java.base/java.lang.Thread.run(Thread.java:830)
10-01-21 03:23:12.167 E:     Exception in thread "intent-processor-5" java.lang.IllegalStateException: spawn.conversationId must not be null
10-01-21 03:23:12.167 E:     Caused by: java.lang.IllegalStateException: spawn.conversationId must not be null
10-01-21 03:23:12.167 E:         holocore/com.projectswg.holocore.resources.support.npc.spawn.Spawner.getConversationId(Spawner.kt:131)
10-01-21 03:23:12.167 E:         holocore/com.projectswg.holocore.services.gameplay.conversation.ConversationService.isConversableNpc(ConversationService.java:197)
10-01-21 03:23:12.167 E:         holocore/com.projectswg.holocore.services.gameplay.conversation.ConversationService.handleObjectCreatedIntent(ConversationService.java:127)
10-01-21 03:23:12.167 E:         jdk.internal.reflect.GeneratedMethodAccessor21.invoke(Unknown Source)
10-01-21 03:23:12.167 E:         java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
10-01-21 03:23:12.167 E:         java.base/java.lang.reflect.Method.invoke(Method.java:567)
10-01-21 03:23:12.167 E:         me.joshlarson.jlcommon/me.joshlarson.jlcommon.control.Service.invoke(Service.java:133)
10-01-21 03:23:12.167 E:         me.joshlarson.jlcommon/me.joshlarson.jlcommon.control.Service.lambda$registerIntentHandlers$1(Service.java:119)
10-01-21 03:23:12.167 E:         me.joshlarson.jlcommon/me.joshlarson.jlcommon.control.IntentManager$IntentRunner.broadcast(IntentManager.java:214)
10-01-21 03:23:12.167 E:         me.joshlarson.jlcommon/me.joshlarson.jlcommon.control.IntentManager$IntentExecutor.run(IntentManager.java:269)
10-01-21 03:23:12.167 E:         me.joshlarson.jlcommon/me.joshlarson.jlcommon.utilities.ThreadUtilities.safeRun(ThreadUtilities.java:47)
10-01-21 03:23:12.167 E:         me.joshlarson.jlcommon/me.joshlarson.jlcommon.concurrency.ThreadPool$ThreadExecutor.threadExecutor(ThreadPool.java:174)
10-01-21 03:23:12.167 E:         java.base/java.lang.Thread.run(Thread.java:830)
```