### PR TITLE
Special line damage increase now applies to healing special lines as well #352

### DIFF
--- a/serverdata/nge/command/special_lines.sdb
+++ b/serverdata/nge/command/special_lines.sdb
@@ -9,7 +9,7 @@ fs_dm		expertise_cooldown_line_fs_dm	expertise_damage_line_fs_dm	expertise_criti
 fs_dm_cc_crit		expertise_cooldown_line_fs_cc_crit	-	expertise_action_line_fs_cc_crit	-	-	-
 fs_sweep		expertise_cooldown_line_fs_sweep	-	-	-	-	-
 me_dm		expertise_cooldown_line_me_evasion	expertise_damage_line_me_dm	expertise_critical_line_me_dm	expertise_action_line_me_dm	-	-
-me_heal		-	-	-	-	expertise_freeshot_me_heal	fast_attack_line_me_heal
+me_heal		-	expertise_healing_line_me_heal	-	-	expertise_freeshot_me_heal	fast_attack_line_me_heal
 of_aoe		-	-	-	expertise_action_line_of_aoe	expertise_freeshot_of_aoe	-
 of_heal		-	-	-	-	-	fast_attack_line_of_heal
 of_paint		expertise_cooldown_line_of_paint	-	-	expertise_action_line_of_paint	-	-

--- a/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandHeal.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandHeal.java
@@ -61,6 +61,9 @@ enum CombatCommandHeal implements CombatCommandHitType {
 			healAmount *= healingPotency;
 		}
 		
+		// Apply special line heal boost
+		healAmount += CombatCommandCommon.getAddedDamageBoost(source, combatCommand);
+		
 		switch (combatCommand.getAttackType()) {
 			case SINGLE_TARGET: {
 				switch (combatCommand.getTargetType()) {


### PR DESCRIPTION
Included example for medic healing abilities.

Fixes #352, although the remaining healing special lines need doing as well.