### PR TITLE
Removed ability to change faction via /pvp command, it must now be done via the recruiters in-game #39

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/global/commands/callbacks/combat/CmdPVP.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/global/commands/callbacks/combat/CmdPVP.java
@@ -3,7 +3,6 @@ package com.projectswg.holocore.resources.support.global.commands.callbacks.comb
 import com.projectswg.common.data.encodables.tangible.PvpFaction;
 import com.projectswg.holocore.intents.gameplay.gcw.faction.FactionIntent;
 import com.projectswg.holocore.intents.support.global.chat.SystemMessageIntent;
-import com.projectswg.holocore.resources.support.data.server_info.loader.ServerData;
 import com.projectswg.holocore.resources.support.global.commands.ICmdCallback;
 import com.projectswg.holocore.resources.support.global.player.Player;
 import com.projectswg.holocore.resources.support.objects.swg.SWGObject;
@@ -16,17 +15,7 @@ public final class CmdPVP implements ICmdCallback {
 	public void execute(@NotNull Player player, SWGObject target, @NotNull String args) {
 		CreatureObject creature = player.getCreatureObject();
 		
-		// Ziggy was using this to test until recruiters are enabled.
-		
-		if (!args.isEmpty()) {
-			if (args.contains("imperial")) {
-				new FactionIntent(creature, ServerData.INSTANCE.getFactions().getFaction("imperial")).broadcast();
-			} else if (args.contains("rebel")) {
-				new FactionIntent(creature, ServerData.INSTANCE.getFactions().getFaction("rebel")).broadcast();
-			} else {
-				new FactionIntent(creature, ServerData.INSTANCE.getFactions().getFaction("neutral")).broadcast();
-			}
-		} else if (creature.getPvpFaction() != PvpFaction.NEUTRAL) {
+		if (creature.getPvpFaction() != PvpFaction.NEUTRAL) {
 			new FactionIntent(creature, FactionIntent.FactionIntentType.SWITCHUPDATE).broadcast();
 		} else {
 			SystemMessageIntent.broadcastPersonal(player, "@faction_recruiter:not_aligned");


### PR DESCRIPTION
Fixes #39

Didn't implement /setFaction, figured we could implement that if we needed it. It's possible to switch factions using the recruiters without having to wait 5 days. Eventually, /setFaction could be nice but for now it doesn't add any value.