### PR TITLE
Removed Restuss from the restricted PVP Zone.

### DIFF
--- a/serverdata/gcw/pvp_zones.sdb
+++ b/serverdata/gcw/pvp_zones.sdb
@@ -2,5 +2,4 @@ pvp_zone_id	terrain	comment	x	z	radius
 INTEGER	TEXT	TEXT	INTEGER	INTEGER	INTEGER
 1	CORELLIA	Corellia GCW base	4722	-5233	200
 2	NABOO	Naboo GCW base	1019	-1508	150
-3	RORI	Restuss	5318	5680	400
-4	TALUS	Talus GCW base	-4899	-3137	150
+3	TALUS	Talus GCW base	-4899	-3137	150


### PR DESCRIPTION
Removed Restuss from the restricted PVP Zone as it's no longer required in the CU.