### PR TITLE
Fixed double loot radial bug #420

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/objects/radial/object/AIObjectRadial.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/radial/object/AIObjectRadial.java
@@ -27,7 +27,7 @@ public class AIObjectRadial implements RadialHandlerInterface {
 			return;
 		}
 		
-		options.add(RadialOption.create(RadialItem.LOOT, RadialOption.create(RadialItem.LOOT_ALL)));
+		options.add(RadialOption.create(RadialItem.LOOT_ALL, RadialOption.create(RadialItem.LOOT)));
 	}
 	
 	@Override

--- a/src/main/java/com/projectswg/holocore/resources/support/objects/radial/object/AIObjectRadial.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/radial/object/AIObjectRadial.java
@@ -21,7 +21,13 @@ public class AIObjectRadial implements RadialHandlerInterface {
 	
 	@Override
 	public void getOptions(Collection<RadialOption> options, Player player, SWGObject target) {
+		AIObject ai = (AIObject) target;
 		
+		if (ai.getPosture() != Posture.DEAD) {
+			return;
+		}
+		
+		options.add(RadialOption.create(RadialItem.LOOT, RadialOption.create(RadialItem.LOOT_ALL)));
 	}
 	
 	@Override

--- a/src/test/java/com/projectswg/holocore/services/support/objects/radials/TestRadialService.java
+++ b/src/test/java/com/projectswg/holocore/services/support/objects/radials/TestRadialService.java
@@ -87,7 +87,7 @@ public class TestRadialService extends TestRunnerSimulatedWorld {
 		registerObject(creature, dead);
 		dead.setPosture(Posture.DEAD);
 		
-		sendRequest(creature, dead, RadialItem.LOOT, RadialItem.EXAMINE);
+		sendRequest(creature, dead, RadialItem.LOOT_ALL, RadialItem.EXAMINE);
 		
 		ObjectMenuResponse response = creature.getOwner().getNextPacket(ObjectMenuResponse.class);
 		Assert.assertNotNull(response);
@@ -95,11 +95,11 @@ public class TestRadialService extends TestRunnerSimulatedWorld {
 		Assert.assertEquals(dead.getObjectId(), response.getTargetId());
 		
 		Assert.assertEquals(2, response.getOptions().size());
-		Assert.assertEquals(RadialItem.LOOT, response.getOptions().get(0).getType());
+		Assert.assertEquals(RadialItem.LOOT_ALL, response.getOptions().get(0).getType());
 		Assert.assertEquals(RadialItem.EXAMINE, response.getOptions().get(1).getType());
 		
 		Assert.assertEquals(1, response.getOptions().get(0).getChildren().size());
-		Assert.assertEquals(RadialItem.LOOT_ALL, response.getOptions().get(0).getChildren().get(0).getType());
+		Assert.assertEquals(RadialItem.LOOT, response.getOptions().get(0).getChildren().get(0).getType());
 	}
 	
 	private void sendRequest(CreatureObject source, SWGObject target, RadialItem ... items) {

--- a/src/test/java/com/projectswg/holocore/services/support/objects/radials/TestRadialService.java
+++ b/src/test/java/com/projectswg/holocore/services/support/objects/radials/TestRadialService.java
@@ -27,6 +27,7 @@
 
 package com.projectswg.holocore.services.support.objects.radials;
 
+import com.projectswg.common.data.encodables.tangible.Posture;
 import com.projectswg.common.data.radial.RadialItem;
 import com.projectswg.common.data.radial.RadialOption;
 import com.projectswg.common.network.packets.swg.zone.object_controller.ObjectMenuRequest;
@@ -34,6 +35,7 @@ import com.projectswg.common.network.packets.swg.zone.object_controller.ObjectMe
 import com.projectswg.holocore.intents.support.global.network.InboundPacketIntent;
 import com.projectswg.holocore.resources.support.objects.swg.SWGObject;
 import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject;
+import com.projectswg.holocore.resources.support.objects.swg.custom.AIObject;
 import com.projectswg.holocore.resources.support.objects.swg.tangible.TangibleObject;
 import com.projectswg.holocore.test.runners.TestRunnerSimulatedWorld;
 import com.projectswg.holocore.test.resources.GenericCreatureObject;
@@ -76,6 +78,28 @@ public class TestRadialService extends TestRunnerSimulatedWorld {
 		Assert.assertEquals(2, response.getOptions().size());
 		Assert.assertEquals(RadialItem.ITEM_USE, response.getOptions().get(0).getType());
 		Assert.assertEquals(RadialItem.ITEM_DESTROY, response.getOptions().get(1).getType());
+	}
+	
+	@Test
+	public void testReplaceLootRadial() {
+		GenericCreatureObject creature = new GenericCreatureObject(getUniqueId());
+		AIObject dead = new AIObject(getUniqueId());
+		registerObject(creature, dead);
+		dead.setPosture(Posture.DEAD);
+		
+		sendRequest(creature, dead, RadialItem.LOOT, RadialItem.EXAMINE);
+		
+		ObjectMenuResponse response = creature.getOwner().getNextPacket(ObjectMenuResponse.class);
+		Assert.assertNotNull(response);
+		Assert.assertEquals(creature.getObjectId(), response.getRequestorId());
+		Assert.assertEquals(dead.getObjectId(), response.getTargetId());
+		
+		Assert.assertEquals(2, response.getOptions().size());
+		Assert.assertEquals(RadialItem.LOOT, response.getOptions().get(0).getType());
+		Assert.assertEquals(RadialItem.EXAMINE, response.getOptions().get(1).getType());
+		
+		Assert.assertEquals(1, response.getOptions().get(0).getChildren().size());
+		Assert.assertEquals(RadialItem.LOOT_ALL, response.getOptions().get(0).getChildren().get(0).getType());
 	}
 	
 	private void sendRequest(CreatureObject source, SWGObject target, RadialItem ... items) {


### PR DESCRIPTION
Fixes #420

Previous attempt was a dud. With some tips on NPC locations from Undercova I found a testing spot and this time it actually works ;)

Code is the original one, _except_ LOOT_ALL is now parent for LOOT instead of the other way around.