### PR TITLE
Fixed behavior where client never dequeued successful commands, becau…

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/support/global/commands/CommandQueueService.java
+++ b/src/main/java/com/projectswg/holocore/services/support/global/commands/CommandQueueService.java
@@ -147,13 +147,11 @@ public class CommandQueueService extends Service {
 						startCooldownGroup(command.getSource(), rootCommand, rootCommand.getCooldownGroup2(), rootCommand.getCooldownTime2(), command.getCounter());
 					}
 					startCooldownGroup(command.getSource(), rootCommand, rootCommand.getCooldownGroup(), rootCommand.getCooldownTime(), command.getCounter());
-				} else {
-					sendQueueRemove(command, error);
 				}
 				ExecuteCommandIntent.broadcast(command.getSource(), command.getTarget(), command.getArguments(), command.getCommand());
-			} else {
-				sendQueueRemove(command, error);
 			}
+			
+			sendQueueRemove(command, error);
 		}
 		
 		private void sendQueueRemove(EnqueuedCommand command, ErrorCode error) {


### PR DESCRIPTION
…se the server only did that in case the command failed

This caused the client to display a command as being "in queue", even after it has been executed.