### PR TITLE
Updates to Static Cities and Travel shuttleports

### DIFF
--- a/serverdata/map/static_city_points.sdf
+++ b/serverdata/map/static_city_points.sdf
@@ -31,7 +31,6 @@ dantooine	Mining Outpost	-640	2486
 dantooine	Pirate Outpost	1588	-6399
 dantooine	Imperial Outpost	-4224	-2400
 dathomir	Trade Outpost	599	3071
-dathomir	Quarentine Zone	-5780	-6550
 dathomir	Science Outpost	-85	-1600
 lok	Nym's Stronghold	440	5029
 lok	Imperial Outpost	-1920	-3084

--- a/serverdata/travel/travel.sdb
+++ b/serverdata/travel/travel.sdb
@@ -18,7 +18,6 @@ dantooine	starport	Imperial Outpost	-4208	-2350
 dantooine	starport	Agro Outpost	1569	-6415
 dathomir	starport	Science Outpost	-49	-1584
 dathomir	starport	Trade Outpost	618	3092
-dathomir	shuttleport	Quarantine Zone	-5688	-6468
 endor	starport	Smuggler Outpost	-950	1553
 endor	starport	Research Outpost	3201	-3500
 lok	starport	Nym's Stronghold	479	5511
@@ -57,7 +56,6 @@ tatooine	shuttleport	Mos Espa Shuttle East	-2801	2182
 tatooine	shuttleport	Mos Espa Shuttle South	-2896	1932
 tatooine	shuttleport	Mos Eisley Shuttleport	3418	-4647
 tatooine	shuttleport	Bestine Shuttleport	-1098	-3562
-tatooine	shuttleport	Wayfar Shuttleport	-5089	-6611
 yavin4	starport	Imperial Base	4054	-6216
 yavin4	starport	Labor Outpost	-6922	-5727
 yavin4	starport	Mining Outpost	-267	4896


### PR DESCRIPTION
Removed both Wayfar and Dathomir Quarantine Zone shuttle ports as neither exist in CU and removed the Dathomir Quarantine Zone city as this is also not present in CU.