### PR TITLE
Fixed sometimes being stuck in combat

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/gameplay/combat/CombatStatusService.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/combat/CombatStatusService.kt
@@ -59,7 +59,9 @@ class CombatStatusService : Service() {
 	@IntentHandler
 	private fun handleExitCombatIntent(eci: ExitCombatIntent) {
 		val source = eci.source
-		val defenders = source.defenders.stream().map { ObjectLookup.getObjectById(it) }.map { CreatureObject::class.java.cast(it) }.collect(Collectors.toList())
+		val defenders = source.defenders.stream()
+				.filter { it != null }
+				.map { ObjectLookup.getObjectById(it) }.map { CreatureObject::class.java.cast(it) }.collect(Collectors.toList())
 		source.clearDefenders()
 		for (defender in defenders) {
 			defender.removeDefender(source)


### PR DESCRIPTION
For whatever reason, a null element can sneak into the defenders Set on TangibleObject. It's a head-scratcher, as we only append the primitive long through TangibleObject#addDefender, which by definition can't be null.