### PR TITLE
Zabrak was missing from "rest" species restrictions, causing them to …

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/objects/StaticItemCreator.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/StaticItemCreator.kt
@@ -149,6 +149,8 @@ object StaticItemCreator {
 			obj.addSpeciesRestriction(Race.SULLUSTAN_MALE)
 			obj.addSpeciesRestriction(Race.TWILEK_FEMALE)
 			obj.addSpeciesRestriction(Race.TWILEK_MALE)
+			obj.addSpeciesRestriction(Race.ZABRAK_FEMALE)
+			obj.addSpeciesRestriction(Race.ZABRAK_MALE)
 		}
 	}
 


### PR DESCRIPTION
…be unable to equip most static items