### PR TITLE
Fixed weapon range not being sent properly to the client

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/objects/swg/weapon/WeaponObject.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/swg/weapon/WeaponObject.java
@@ -254,7 +254,6 @@ public class WeaponObject extends TangibleObject {
 	public void createBaseline3(Player target, BaselineBuilder bb) {
 		super.createBaseline3(target, bb);
 		
-		bb.addFloat(attackSpeed);
 		bb.addInt(accuracy); // pre-NGE
 		bb.addFloat(minRange);
 		bb.addFloat(maxRange);
@@ -262,7 +261,7 @@ public class WeaponObject extends TangibleObject {
 		bb.addInt(elementalType == null ? 0 : elementalType.getNum());
 		bb.addInt(elementalValue); // elementalValue
 		
-		bb.incrementOperandCount(7);
+		bb.incrementOperandCount(6);
 	}
 	
 	@Override
@@ -277,7 +276,6 @@ public class WeaponObject extends TangibleObject {
 	@Override
 	public void parseBaseline3(NetBuffer buffer) {
 		super.parseBaseline3(buffer);
-		attackSpeed = buffer.getFloat();
 		buffer.getInt(); // accuracy
 		buffer.getFloat(); // minRange
 		maxRange = buffer.getFloat();


### PR DESCRIPTION
We had attackSpeed in the top of WEAO03, but attackSpeed isn't in there at all post-CU. This caused all variables to be off-by-one.

Fixes #621, tested locally