### PR TITLE
Holocore-650 Failed command execution should fail instead of triggeri…

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/gameplay/combat/CombatManager.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/combat/CombatManager.java
@@ -28,7 +28,6 @@ package com.projectswg.holocore.services.gameplay.combat;
 
 import com.projectswg.holocore.services.gameplay.combat.buffs.BuffService;
 import com.projectswg.holocore.services.gameplay.combat.cloning.CloningService;
-import com.projectswg.holocore.services.gameplay.combat.command.CombatCommandService;
 import com.projectswg.holocore.services.gameplay.combat.duel.DuelService;
 import com.projectswg.holocore.services.gameplay.combat.loot.LootManager;
 import me.joshlarson.jlcommon.control.Manager;
@@ -39,7 +38,6 @@ import me.joshlarson.jlcommon.control.ManagerStructure;
 		CloningService.class,
 		DuelService.class,
 		LootManager.class,
-		CombatCommandService.class,
 		CombatDeathblowService.class,
 		CombatExperienceService.class,
 		CombatNpcService.class,

--- a/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandAttack.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandAttack.java
@@ -63,13 +63,15 @@ enum CombatCommandAttack implements CombatCommandHitType {
 	INSTANCE;
 	
 	@Override
-	public void handle(@NotNull CreatureObject source, @Nullable SWGObject target, @NotNull CombatCommand command, @NotNull String arguments) {
-		handle(source, target, null, command);
+	public CombatStatus handle(@NotNull CreatureObject source, @Nullable SWGObject target, @NotNull CombatCommand command, @NotNull String arguments) {
+		return handle(source, target, null, command);
 	}
 	
-	public void handle(CreatureObject source, SWGObject target, SWGObject delayEgg, CombatCommand command) {
-		if (!handleStatus(source, canPerform(source, target, command)))
-			return;
+	public CombatStatus handle(CreatureObject source, SWGObject target, SWGObject delayEgg, CombatCommand command) {
+		CombatStatus combatStatus = canPerform(source, target, command);
+		if (combatStatus != CombatStatus.SUCCESS) {
+			return combatStatus;
+		}
 		
 		for (int i = 0; i < command.getAttackRolls(); i++) {
 			AttackInfo info = new AttackInfo();
@@ -100,6 +102,8 @@ enum CombatCommandAttack implements CombatCommandHitType {
 					break;
 			}
 		}
+		
+		return combatStatus;
 	}
 	
 	private void doCombatCone(CreatureObject source, Location targetWorldLocation, AttackInfo info, CombatCommand command) {

--- a/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandBuff.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandBuff.java
@@ -27,6 +27,7 @@
 
 package com.projectswg.holocore.services.gameplay.combat.command;
 
+import com.projectswg.common.data.combat.CombatStatus;
 import com.projectswg.common.data.combat.HitLocation;
 import com.projectswg.common.data.combat.TrailLocation;
 import com.projectswg.common.data.encodables.tangible.PvpStatus;
@@ -47,7 +48,8 @@ import static com.projectswg.holocore.services.gameplay.combat.command.CombatCom
 enum CombatCommandBuff implements CombatCommandHitType {
 	INSTANCE;
 	
-	public void handle(@NotNull CreatureObject source, @Nullable SWGObject targetPrecheck, @NotNull CombatCommand combatCommand, @NotNull String arguments) {
+	@Override
+	public CombatStatus handle(@NotNull CreatureObject source, @Nullable SWGObject targetPrecheck, @NotNull CombatCommand combatCommand, @NotNull String arguments) {
 		// TODO group buffs
 		addBuff(source, source, combatCommand.getBuffNameSelf());
 		
@@ -72,6 +74,8 @@ enum CombatCommandBuff implements CombatCommandHitType {
 		if (!buffNameTarget.isEmpty()) {
 			combatAction.addDefender(new Defender(target.getObjectId(), effectiveTarget.getPosture(), false, (byte) 0, HitLocation.HIT_LOCATION_BODY, (short) 0));
 		}
+		
+		return CombatStatus.SUCCESS;
 	}
 	
 	private boolean isApplyToSelf(CreatureObject source, CreatureObject target) {

--- a/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandCommon.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandCommon.java
@@ -91,7 +91,7 @@ public class CombatCommandCommon {
 			return CombatStatus.NO_WEAPON;
 		
 		if (target == null || source.equals(target))
-			return CombatStatus.SUCCESS;
+			return CombatStatus.INVALID_TARGET;
 		
 		if (!(target instanceof TangibleObject))
 			return CombatStatus.INVALID_TARGET;
@@ -159,22 +159,12 @@ public class CombatCommandCommon {
 		new BuffIntent(buffName, caster, receiver, false).broadcast();
 	}
 	
-	static boolean handleStatus(CreatureObject source, CombatStatus status) {
+	public static void handleStatus(CreatureObject source, CombatStatus status) {
 		switch (status) {
-			case SUCCESS:
-				return true;
-			case NO_TARGET:
-				showFlyText(source, "@combat_effects:target_invalid_fly", Scale.MEDIUM, COLOR_WHITE, ShowFlyText.Flag.PRIVATE);
-				return false;
-			case TOO_FAR:
-				showFlyText(source, "@combat_effects:range_too_far", Scale.MEDIUM, COLOR_CYAN, ShowFlyText.Flag.PRIVATE);
-				return false;
-			case INVALID_TARGET:
-				showFlyText(source, "@combat_effects:target_invalid_fly", Scale.MEDIUM, COLOR_CYAN, ShowFlyText.Flag.PRIVATE);
-				return false;
-			default:
-				showFlyText(source, "@combat_effects:action_failed", Scale.MEDIUM, COLOR_WHITE, ShowFlyText.Flag.PRIVATE);
-				return false;
+			case NO_TARGET -> showFlyText(source, "@combat_effects:target_invalid_fly", Scale.MEDIUM, COLOR_WHITE, ShowFlyText.Flag.PRIVATE);
+			case TOO_FAR -> showFlyText(source, "@combat_effects:range_too_far", Scale.MEDIUM, COLOR_CYAN, ShowFlyText.Flag.PRIVATE);
+			case INVALID_TARGET -> showFlyText(source, "@combat_effects:target_invalid_fly", Scale.MEDIUM, COLOR_CYAN, ShowFlyText.Flag.PRIVATE);
+			default -> showFlyText(source, "@combat_effects:action_failed", Scale.MEDIUM, COLOR_WHITE, ShowFlyText.Flag.PRIVATE);
 		}
 	}
 	

--- a/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandDebuff.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandDebuff.kt
@@ -1,12 +1,13 @@
 package com.projectswg.holocore.services.gameplay.combat.command
 
+import com.projectswg.common.data.combat.CombatStatus
 import com.projectswg.holocore.intents.gameplay.combat.EnterCombatIntent
 import com.projectswg.holocore.resources.support.global.commands.CombatCommand
 import com.projectswg.holocore.resources.support.objects.swg.SWGObject
 import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject
 
 object CombatCommandDebuff : CombatCommandHitType {
-	override fun handle(source: CreatureObject, target: SWGObject?, combatCommand: CombatCommand, arguments: String) {
+	override fun handle(source: CreatureObject, target: SWGObject?, combatCommand: CombatCommand, arguments: String): CombatStatus {
 		if (target is CreatureObject) {
 			if (source.isAttackable(target)) {
 				val hateAdd: Int = combatCommand.hateAdd
@@ -14,7 +15,11 @@ object CombatCommandDebuff : CombatCommandHitType {
 				source.updateLastCombatTime()
 				EnterCombatIntent.broadcast(source, target)
 				EnterCombatIntent.broadcast(target, source)
+				
+				return CombatStatus.SUCCESS
 			}
 		}
+		
+		return CombatStatus.INVALID_TARGET
 	}
 }

--- a/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandDelayAttack.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandDelayAttack.java
@@ -27,6 +27,7 @@
 
 package com.projectswg.holocore.services.gameplay.combat.command;
 
+import com.projectswg.common.data.combat.CombatStatus;
 import com.projectswg.common.data.location.Location;
 import com.projectswg.common.network.packets.swg.zone.PlayClientEffectObjectMessage;
 import com.projectswg.holocore.intents.support.objects.swg.DestroyObjectIntent;
@@ -61,7 +62,7 @@ enum CombatCommandDelayAttack implements CombatCommandHitType {
 	}
 	
 	@Override
-	public void handle(@NotNull CreatureObject source, @Nullable SWGObject target, @NotNull CombatCommand combatCommand, @NotNull String arguments) {
+	public CombatStatus handle(@NotNull CreatureObject source, @Nullable SWGObject target, @NotNull CombatCommand combatCommand, @NotNull String arguments) {
 		String[] argSplit = arguments.split(" ");
 		Location eggLocation;
 		SWGObject eggParent;
@@ -99,6 +100,7 @@ enum CombatCommandDelayAttack implements CombatCommandHitType {
 		
 		long interval = (long) (combatCommand.getInitialDelayAttackInterval() * 1000);
 		executor.execute(interval, () -> delayEggLoop(delayEgg, source, target, combatCommand, 1));
+		return CombatStatus.SUCCESS;
 	}
 	
 	private void delayEggLoop(final SWGObject delayEgg, final CreatureObject source, final SWGObject target, final CombatCommand combatCommand, final int currentLoop) {

--- a/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandHitType.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandHitType.java
@@ -27,6 +27,7 @@
 
 package com.projectswg.holocore.services.gameplay.combat.command;
 
+import com.projectswg.common.data.combat.CombatStatus;
 import com.projectswg.holocore.resources.support.global.commands.CombatCommand;
 import com.projectswg.holocore.resources.support.objects.swg.SWGObject;
 import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject;
@@ -41,6 +42,6 @@ public interface CombatCommandHitType {
 	default void terminate() {
 		
 	}
-	void handle(@NotNull CreatureObject source, @Nullable SWGObject target, @NotNull CombatCommand combatCommand, @NotNull String arguments);
+	CombatStatus handle(@NotNull CreatureObject source, @Nullable SWGObject target, @NotNull CombatCommand combatCommand, @NotNull String arguments);
 	
 }

--- a/src/test/java/com/projectswg/holocore/services/gameplay/combat/AttackCostTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/combat/AttackCostTest.kt
@@ -6,7 +6,6 @@ import com.projectswg.holocore.intents.support.global.network.InboundPacketInten
 import com.projectswg.holocore.intents.support.objects.swg.ObjectCreatedIntent
 import com.projectswg.holocore.resources.support.objects.ObjectCreator
 import com.projectswg.holocore.resources.support.objects.swg.weapon.DefaultWeaponFactory
-import com.projectswg.holocore.services.gameplay.combat.command.CombatCommandService
 import com.projectswg.holocore.services.support.global.commands.CommandExecutionService
 import com.projectswg.holocore.services.support.global.commands.CommandQueueService
 import com.projectswg.holocore.test.resources.GenericCreatureObject
@@ -22,7 +21,6 @@ class AttackCostTest : TestRunnerSimulatedWorld() {
 	fun setup() {
 		registerService(CommandQueueService())
 		registerService(CommandExecutionService())
-		registerService(CombatCommandService())
 		registerService(CombatStatusService())
 	}
 

--- a/src/test/java/com/projectswg/holocore/services/gameplay/combat/FactionPvpTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/combat/FactionPvpTest.kt
@@ -11,7 +11,6 @@ import com.projectswg.holocore.resources.support.global.commands.State
 import com.projectswg.holocore.resources.support.objects.ObjectCreator
 import com.projectswg.holocore.resources.support.objects.swg.SWGObject
 import com.projectswg.holocore.resources.support.objects.swg.weapon.DefaultWeaponFactory
-import com.projectswg.holocore.services.gameplay.combat.command.CombatCommandService
 import com.projectswg.holocore.services.gameplay.faction.FactionFlagService
 import com.projectswg.holocore.services.support.global.commands.CommandExecutionService
 import com.projectswg.holocore.services.support.global.commands.CommandQueueService
@@ -28,7 +27,6 @@ class FactionPvpTest : TestRunnerSimulatedWorld() {
 	fun setup() {
 		registerService(CommandQueueService())
 		registerService(CommandExecutionService())
-		registerService(CombatCommandService())
 		registerService(FactionFlagService())
 		registerService(CombatStatusService())
 	}


### PR DESCRIPTION
…ng cooldown

I had to make CombatCommandService run as a part of CommandQueueService, so we have a chance to make commands fail properly based on combatcommand-specific checks.

Relates to #650