### PR TITLE
Fixed an issue where trigger effects for combat commands would never …

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/support/global/commands/CommandQueueService.java
+++ b/src/main/java/com/projectswg/holocore/services/support/global/commands/CommandQueueService.java
@@ -225,9 +225,9 @@ public class CommandQueueService extends Service {
 						rootCommand,
 						combatCommand,
 						command.getArguments());
-				
+
+				CombatCommandCommon.handleStatus(source, combatCommand, combatStatus);
 				if (combatStatus != CombatStatus.SUCCESS) {
-					CombatCommandCommon.handleStatus(source, combatCommand, combatStatus);
 					sendCommandFailed(command);
 					return;
 				}


### PR DESCRIPTION
…display

Basically, CombatStatus had to be != SUCCESS and also == SUCCESS at the same time. This of course caused them to never display.