### PR TITLE
Healing Efficiency now increases damage healed as a percentage

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandHeal.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandHeal.java
@@ -51,11 +51,11 @@ enum CombatCommandHeal implements CombatCommandHitType {
 	@Override
 	public CombatStatus handle(@NotNull CreatureObject source, @Nullable SWGObject target, @NotNull Command command, @NotNull CombatCommand combatCommand, @NotNull String arguments) {
 		int healAmount = combatCommand.getAddedDamage();
-		int healingPotency = source.getSkillModValue("expertise_healing_all");
+		int healingEfficiency = source.getSkillModValue("healing_efficiency");
 		int healedDamage = 0;
 
-		if (healingPotency > 0) {
-			healAmount *= healingPotency;
+		if (healingEfficiency > 0) {
+			healAmount *= (healingEfficiency / 100d);
 		}
 		
 		switch (combatCommand.getAttackType()) {


### PR DESCRIPTION
As an example, +45 Healing Efficiency would increase the amount of damage normally healed by 45%

Relates to #919