### PR TITLE
marker.txt detection no longer opens an InputStream that's never closed

### DIFF
--- a/src/main/java/com/projectswg/holocore/ProjectSWG.java
+++ b/src/main/java/com/projectswg/holocore/ProjectSWG.java
@@ -1,5 +1,5 @@
 /***********************************************************************************
- * Copyright (c) 2018 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
  * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
@@ -97,7 +97,7 @@ public class ProjectSWG {
 		}
 		
 		setupLogging(arguments);
-		if (ProjectSWG.class.getResourceAsStream("/marker.txt") == null) {
+		if (ProjectSWG.class.getResource("/marker.txt") == null) {
 			Log.a("Failed to read Holocore resources - aborting");
 			return -1;
 		}


### PR DESCRIPTION
I saw two options:
1. Closing the InputStream that was opened
2. Not opening an InputStream to begin with

I figured simply creating an `URL` would also do what we wanted, keeping the code simple.