### PR TITLE
[General] Fixed a bug where you had to relog to see new names for way…

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/objects/swg/player/PlayerObjectOwner.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/swg/player/PlayerObjectOwner.java
@@ -1,5 +1,5 @@
 /***********************************************************************************
- * Copyright (c) 2018 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
  * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
@@ -102,9 +102,9 @@ class PlayerObjectOwner implements MongoPersistable {
 		}
 	}
 	
-	public void updateWaypoint(WaypointObject obj) {
+	public void updateWaypoint(WaypointObject waypoint) {
 		synchronized (waypoints) {
-			waypoints.update(obj.getObjectId());
+			waypoints.update(waypoint.getObjectId());
 			waypoints.sendDeltaMessage(obj);
 		}
 	}


### PR DESCRIPTION
…points

Relates to GitHub issue #749

Basically, it was trying to send deltas based on the observers of the `WaypointObject`.
For similar methods, the deltas were sent based on the `PlayerObject` field. Switching to the field worked, because `WaypointObject` had 0 observers while the `PlayerObject` has the player as an observer.