### PR TITLE
[Faction] Switching factions resets your faction rank

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/gameplay/faction/FactionFlagService.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/faction/FactionFlagService.java
@@ -178,6 +178,9 @@ public class FactionFlagService extends Service {
 		
 		target.setFaction(newFaction);
 		target.setPvpStatus(PvpStatus.COMBATANT);	// Reset status to default, preventing special forces state from carrying over
+		if (target instanceof CreatureObject creatureObject) {
+			creatureObject.setFactionRank((byte) 0);
+		}
 		handleFlagChange(target);
 	}
 	


### PR DESCRIPTION
Relates to GitHub issue #1267

**NOTE**: This can't _really_ happen yet, as the only way to progress in faction rank is to edit your character in MongoDB directly.
But it will be possible with #1225.