### PR TITLE
[Mission] Terminal missions spawn lairs

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/npc/spawn/NPCCreator.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/npc/spawn/NPCCreator.java
@@ -1,5 +1,5 @@
 /***********************************************************************************
- * Copyright (c) 2018 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
  * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
@@ -53,14 +53,27 @@ import me.joshlarson.jlcommon.control.IntentChain;
 import me.joshlarson.jlcommon.log.Log;
 import me.joshlarson.jlcommon.utilities.Arguments;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class NPCCreator {
 	
-	public static AIObject createNPC(Spawner spawner) {
+	public static Collection<AIObject> createNPCs(Spawner spawner) {
 		Arguments.validate(spawner.getMinLevel() <= spawner.getMaxLevel(), "min level must be less than max level");
+		int amount = spawner.getAmount();
+		Collection<AIObject> npcs = new ArrayList<>();
+		
+		for (int i = 0; i < amount; i++) {
+			npcs.add(createNPC(spawner));
+		}
+		
+		return npcs;
+	}
+	
+	private static AIObject createNPC(Spawner spawner) {
 		int combatLevel = ThreadLocalRandom.current().nextInt(spawner.getMinLevel(), spawner.getMaxLevel()+1);
 		AIObject object = ObjectCreator.createObjectFromTemplate(spawner.getRandomIffTemplate(), AIObject.class);
 		

--- a/src/main/java/com/projectswg/holocore/services/support/npc/spawn/SpawnerService.kt
+++ b/src/main/java/com/projectswg/holocore/services/support/npc/spawn/SpawnerService.kt
@@ -1,29 +1,29 @@
 /***********************************************************************************
- * Copyright (c) 2018 /// Project SWG /// www.projectswg.com                       *
- * *
+ * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
  * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
  * Our goal is to create an emulator which will provide a server for players to    *
  * continue playing a game similar to the one they used to play. We are basing     *
  * it on the final publish of the game prior to end-game events.                   *
- * *
+ *                                                                                 *
  * This file is part of Holocore.                                                  *
- * *
+ *                                                                                 *
  * --------------------------------------------------------------------------------*
- * *
+ *                                                                                 *
  * Holocore is free software: you can redistribute it and/or modify                *
  * it under the terms of the GNU Affero General Public License as                  *
  * published by the Free Software Foundation, either version 3 of the              *
  * License, or (at your option) any later version.                                 *
- * *
+ *                                                                                 *
  * Holocore is distributed in the hope that it will be useful,                     *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
  * GNU Affero General Public License for more details.                             *
- * *
+ *                                                                                 *
  * You should have received a copy of the GNU Affero General Public License        *
- * along with Holocore.  If not, see <http:></http:>//www.gnu.org/licenses/>.               *
- */
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
 package com.projectswg.holocore.services.support.npc.spawn
 
 import com.projectswg.common.data.location.Location
@@ -153,7 +153,9 @@ class SpawnerService : Service() {
 			val respawnDelay = spawner.respawnDelay
 
 			if (respawnDelay > 0) {
-				executor.execute((respawnDelay * 1000).toLong()) { respawn(spawner) }
+				executor.execute((respawnDelay * 1000).toLong()) {
+					NPCCreator.createNPCs(spawner)
+				}
 			} else {
 				DestroyObjectIntent.broadcast(spawner.egg)
 			}
@@ -199,10 +201,8 @@ class SpawnerService : Service() {
 		val egg = createEgg(spawn)
 		val spawner = Spawner(spawn, egg)
 		egg.setServerAttribute(ServerAttribute.EGG_SPAWNER, spawner)
-		
-		for (i in 0 until spawner.amount) {
-			NPCCreator.createNPC(spawner)
-		}
+
+		NPCCreator.createNPCs(spawner)
 		
 		val patrolRoute = spawner.patrolRoute
 		if (patrolRoute != null) {
@@ -217,13 +217,7 @@ class SpawnerService : Service() {
 			}
 		}
 	}
-	
-	private fun respawn(spawner: Spawner) {
-		for (i in spawner.npcs.size until spawner.amount) {
-			NPCCreator.createNPC(spawner)
-		}
-	}
-	
+
 	private fun createEgg(spawn: SpawnInfo): SWGObject {
 		val spawnerType = SpawnerType.valueOf(spawn.spawnerType)
 		val egg = ObjectCreator.createObjectFromTemplate(spawnerType.objectTemplate)

--- a/src/test/java/com/projectswg/holocore/services/gameplay/combat/NpcDefaultAttackTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/combat/NpcDefaultAttackTest.kt
@@ -1,3 +1,29 @@
+/***********************************************************************************
+ * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
 package com.projectswg.holocore.services.gameplay.combat
 
 import com.projectswg.common.data.location.Location
@@ -8,7 +34,6 @@ import com.projectswg.holocore.resources.support.npc.spawn.Spawner
 import com.projectswg.holocore.resources.support.objects.ObjectCreator
 import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureDifficulty
 import com.projectswg.holocore.resources.support.objects.swg.custom.AIObject
-import com.projectswg.holocore.resources.support.objects.swg.weapon.WeaponObject
 import com.projectswg.holocore.test.runners.TestRunnerSynchronousIntents
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -55,7 +80,7 @@ class NpcDefaultAttackTest : TestRunnerSynchronousIntents() {
 				.withLocation(inFrontOfMosEisleyStarport)
 				.build()
 
-		return NPCCreator.createNPC(Spawner(spawnInfo, egg))
+		return NPCCreator.createNPCs(Spawner(spawnInfo, egg)).first()
 	}
 
 }


### PR DESCRIPTION
Relates to GitHub issue #1275

**NOTE**: The `NPCCreator` wasn't responsible for spawning the requested amount of NPCs, so you would always have to do this yourself despite "amount" of NPCs being a thing on spawners.
This has been changed, so spawning NPCs is easier.