### PR TITLE
Dependabot automatically updating GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+      day: "saturday"


### PR DESCRIPTION
Based on: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

We currently have a warning on our test runs (and probably deploy runs), because our build pipeline hasn't really been updated.

![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/09d38a18-153f-4dbf-bf8c-fdad5f9df13f)

Just having them updated automatically through pull requests seemed to make sense, when it was this easy to implement.