### PR TITLE
Docker image timezone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ ADD serverdata/ /holocore/serverdata
 # Sets up networking
 EXPOSE 44463/tcp
 
+# Sets up timezone - default timezone can be overridden by setting TZ environment variable.
+RUN apt-get install -y tzdata
+ENV TZ=UTC
+
 # Sets up execution
 WORKDIR /holocore
 ENTRYPOINT ["/holocore/bin/java", "-m", "holocore/com.projectswg.holocore.ProjectSWG", "--database", "mongodb://pswg_game_database", "--dbName", "cu"]


### PR DESCRIPTION
Fixes #1342

Running the Docker image unaltered, you can see the time of my Docker host not matching the Docker container.
The log lines say 15:13 (UTC), but actually it's 17:13 (GMT +2).
Being on Windows, it isn't possible to passthrough /etc/localtime as a volume mount.
![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/4b04d92f-bb4f-4630-8284-148b3f817e1e)

This is still the default behavior, as UTC time is just the Docker default. However, we can now customize it like so:
`docker run -e TZ=Europe/Copenhagen <image>`
![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/db4a5752-8cd2-43c3-9760-7199602b4e9a)
