### PR TITLE
Dockerfile overhaul

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.gradle
+build
+log
+mongo_data
+pswgcommon/build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,12 +13,6 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: true
-    - name: Set up JDK 18
-      uses: actions/setup-java@v1
-      with:
-        java-version: 18
-    - name: Build
-      run: ./gradlew --no-daemon clean test jlink
     - name: Docker Login
       run: docker login docker.pkg.github.com -u "${{ secrets.DOCKER_USER }}" -p "${{ secrets.DOCKER_PASS }}"
     - name: Docker Build & Push

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,4 +1,4 @@
-name: Gradle Test
+name: Test
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
     - cu_quality_assurance
 
 jobs:
-  test:
+  code:
 
     runs-on: ubuntu-latest
 
@@ -23,3 +23,14 @@ jobs:
         java-version: 18
     - name: Test with Gradle
       run: ./gradlew --no-daemon test
+
+  docker_build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - run: |
+          docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
-FROM debian:stretch-slim
+FROM eclipse-temurin:18.0.2.1_1-jdk-alpine AS builder
+WORKDIR /holocore
+ADD . /holocore
+
+RUN ./gradlew --no-daemon jlink
+
+FROM alpine:3.18.3 AS runner
 
 # Adds necessary Holocore files
 RUN mkdir /holocore
-ADD build/holocore/ /holocore
+COPY --from=builder /holocore/build/holocore/ /holocore
 ADD serverdata/ /holocore/serverdata
 
 # Sets up networking
 EXPOSE 44463/tcp
 
 # Sets up timezone - default timezone can be overridden by setting TZ environment variable.
-RUN apt-get install -y tzdata
+RUN apk add --no-cache tzdata
 ENV TZ=UTC
 
 # Sets up execution


### PR DESCRIPTION
Fixes #1351

In short:
* CI/CD pipeline now attempts to build the docker image, so we can have more confidence that it's actually working
* Running jlink now happens inside the docker image build, so it's portable
* Final Docker image size has been reduced by ~30% (240MB -> 170MB)

# Dependabot
As for automatic updates to the base image using Dependabot, being a multi-stage build now, we appear to have lost the option to have Dependabot submit update PRs: https://github.com/dependabot/dependabot-core/issues/7640
_Technically_ we could work around it by having two Dockerfiles, as described in that issue, but I'm unsure if the added complexity is worth it at this time.

# Docker image size
Debian Stretch has been replaced with Alpine 3.
Docker image size difference, Alpine vs. Debian:

![Screenshot from 2023-08-18 23-52-26](https://github.com/ProjectSWGCore/Holocore/assets/4640241/40c28969-61a5-4c8b-a549-39b124bed9e4)