### PR TITLE
OpenID Connect (OIDC) support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,21 +27,27 @@ Clone them by running: `git submodule update --init`.
 
 You may have to manually update the submodules in the future, if they become outdated: `git submodule update`.
 
-### MongoDB
-A MongoDB instance can be bootstrapped by running `docker-compose up -d`.
+### Running dependencies
+All runtime dependencies of Holocore can be bootstrapped by running `docker-compose up -d`.
 
-This will run and initialize a MongoDB instance with a default game server user.
-* Username: user
-* Password: pass
+MongoDB and a web UI: http://localhost:8081
 
-This will also run a web UI, which can be accessed in the browser at: http://localhost:8081
+Keycloak for user management: http://localhost:8080
 
-You can stop both with: `docker-compose down`.
+Keycloak has been configured with a default _administrative_ user (won't work for game logins!):
+* **Username:** admin
+* **Password:** admin
+
+You can stop all dependencies with: `docker-compose down`.
 
 ### Running Holocore
-In IntelliJ idea, run the **Start server (development)** run configuration.
+**NOTE**: The dependencies must be running first!
 
-**NOTE**: A MongoDB instance must be running for the server to start.
+In IntelliJ IDEA, run the **Start server (development)** run configuration.
+
+At this point, you should be able to sign in with the default game user:
+* **Username:** user
+* **Password:** pass
 
 ### Running automated tests
 In IntelliJ idea, run the **Tests** run configuration.

--- a/HOSTING.md
+++ b/HOSTING.md
@@ -1,0 +1,57 @@
+# Running your own server
+Ready to run our own Holocore server? Great! This document will guide you through the process.
+
+## Warning
+Holocore is currently still in early development, and not yet ready for public use. Breaking changes may occur at any time.
+
+If you're interested in running your own Holocore server anyway, read on.
+
+## Docker
+The only supported way to deploy Holcore is using Docker.
+We regularly push new Docker images to [GitHub Packages](https://github.com/ProjectSWGCore/Holocore/pkgs/container/Holocore%2Fholocore).
+
+## User database
+User databases are used to authenticate players and generate session tokens. It's a required component for the game server to function.
+
+There are currently two user database implementations available:
+### 1. An OpenID Connect implementation
+The recommended option for **production use**.
+Activate the integration in MongoDB like so, replacing values as needed:
+```js
+db.config.insertOne({
+	package: "support.data.server_info.oidc",
+	authorizationServerBaseURI: "http://localhost:8080/realms/swg",
+	wellKnownConfigurationURI: ".well-known/openid-configuration",
+	clientId: "holocore-localhost",
+	clientSecret: "nrrtW0NqbNWXn62ii6218QHWbEhVGXaf"
+});
+```
+
+Optional information can be added to the `userprofile` of a user for an optimal experience. These are:
+1. `banned` (boolean)
+2. `roles` (array of strings, representing which roles the user has on the game server)
+
+   These can be the following, ordered from least to most privileges:
+   1. PLAYER
+   2. WARDEN
+   3. QA		
+   4. CSR		
+   5. LEAD_QA
+   6. LEAD_CSR
+   7. DEV
+### 2. A MongoDB implementation
+The recommended option for **testing purposes**.
+Simply create a user for yourself in MongoDB:
+```js
+db.users.insert({
+	username: "user",
+	password: "pass",
+	accessLevel: "dev",
+	banned: false, 
+	characters: []
+});
+```
+
+## Game database
+Game databases are used to store all game data, such as items, characters, etc. It's a required component for the game server to function.
+The only supported game database implementation is MongoDB.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,7 @@ era of the game.
 If you're interested in contributing to the project, please see our [contributing guide](CONTRIBUTING.md).
 
 ## Running your own server
-Warning: Holocore is still in early development, and not yet ready for public use. Breaking changes may occur at any time.
-
-If you're interested in running your own Holocore server anyway, you can use the provided Docker image.
-
-We regularly push new images to [GitHub Packages](https://github.com/ProjectSWGCore/Holocore/pkgs/container/Holocore%2Fholocore).
+If you're interested in running your own Holocore server, please see our [hosting guide](HOSTING.md).
 
 ## Help needed ?
 If you have questions or stuck, please use the channels on Discord [![Discord chat](https://img.shields.io/discord/373548910225915905?logo=discord)](https://discord.gg/BWhBx4F)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,7 +73,8 @@ dependencies {
 	implementation(group="me.joshlarson", name="jlcommon-network", version="1.1.0")
 	implementation(group="me.joshlarson", name="jlcommon-argparse", version="0.9.6")
 	implementation(group="me.joshlarson", name="websocket", version="0.9.4")
-	
+	implementation(group="com.auth0", name="java-jwt", version="4.4.0")
+
 	utilityImplementation(project(":"))
 	utilityImplementation(project(":pswgcommon"))
 	
@@ -85,6 +86,7 @@ dependencies {
 	testRuntimeOnly(group="org.slf4j", name="slf4j-simple", version="1.7.36")
 
 	testImplementation("com.tngtech.archunit:archunit-junit5:1.0.1")
+	testImplementation("com.github.dasniko:testcontainers-keycloak:3.0.0")
 }
 
 idea {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,17 @@ services:
       timeout: 5s
       retries: 5
       start_period: 5s
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:22.0.3
+    ports:
+      - "8080:8080"
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    volumes:
+      # Realms in ./keycloak_import will be imported on first start
+      # Exporting a realm can be done like this while the container is running:
+      # $ docker exec -it holocore-keycloak-1 /opt/keycloak/bin/kc.sh export --dir /opt/keycloak/data/import --users realm_file
+      - ./keycloak_import:/opt/keycloak/data/import
+    command: start-dev --import-realm

--- a/keycloak_import/master-realm.json
+++ b/keycloak_import/master-realm.json
@@ -1,0 +1,1946 @@
+{
+  "id" : "f17ca52e-0f6b-41ea-9d4c-236688d89f6a",
+  "realm" : "master",
+  "displayName" : "Keycloak",
+  "displayNameHtml" : "<div class=\"kc-logo-text\"><span>Keycloak</span></div>",
+  "notBefore" : 0,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 60,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "4620df8a-27e0-4d5d-9dea-454747d5735f",
+      "name" : "create-realm",
+      "description" : "${role_create-realm}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "f17ca52e-0f6b-41ea-9d4c-236688d89f6a",
+      "attributes" : { }
+    }, {
+      "id" : "f8e466fd-2dc0-4b64-86f3-9dd75781fb5f",
+      "name" : "admin",
+      "description" : "${role_admin}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "create-realm" ],
+        "client" : {
+          "master-realm" : [ "view-authorization", "query-users", "view-identity-providers", "view-realm", "manage-clients", "manage-realm", "query-realms", "create-client", "view-events", "query-groups", "manage-users", "manage-identity-providers", "view-clients", "manage-events", "query-clients", "impersonation", "manage-authorization", "view-users" ],
+          "swg-realm" : [ "manage-authorization", "manage-clients", "view-users", "manage-realm", "query-users", "view-realm", "view-events", "view-authorization", "view-clients", "query-clients", "manage-events", "query-groups", "manage-users", "manage-identity-providers", "create-client", "query-realms", "impersonation", "view-identity-providers" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "f17ca52e-0f6b-41ea-9d4c-236688d89f6a",
+      "attributes" : { }
+    }, {
+      "id" : "eb36b67b-0685-47ab-95e2-684234293438",
+      "name" : "default-roles-master",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
+        "client" : {
+          "account" : [ "view-profile", "manage-account" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "f17ca52e-0f6b-41ea-9d4c-236688d89f6a",
+      "attributes" : { }
+    }, {
+      "id" : "03f3dc29-d2bd-414a-adc2-60fec8d9b720",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "f17ca52e-0f6b-41ea-9d4c-236688d89f6a",
+      "attributes" : { }
+    }, {
+      "id" : "497c124c-a604-4cc2-99af-94c64ba5623a",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "f17ca52e-0f6b-41ea-9d4c-236688d89f6a",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "8e191822-7700-4966-9e30-77bb4f71eb71",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "6aac5c5b-ab72-468c-bdb2-4e7edbd94c06",
+        "attributes" : { }
+      } ],
+      "master-realm" : [ {
+        "id" : "4d59bea9-7712-4449-ae2c-f2feabb5a070",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "65109345-608d-4724-a7ce-4b53052124b0",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "a3c9b7ed-aece-4b27-9b94-a9cb98fd948d",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "97ed639b-5949-4b94-88f4-5966db97474a",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "02988f7b-f01b-4544-827d-6d27e52154f2",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "0d1f490b-c554-4524-a632-e438851c065b",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "1573ff07-44c6-4ff6-9a58-dedba4435312",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "ca28b742-01e1-4e90-b239-780554375076",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "master-realm" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "cc9ef925-dbc4-49d6-a29f-08646e9b10db",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "30e6e0e2-b051-461e-ab43-19a0c4375547",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "13c3a81a-0854-499a-a526-0f6e25deba53",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "2baf250d-2d0c-4f38-8d4d-1550dec9f1c8",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "02a40480-e3a4-4b3e-9e76-968124668694",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "d244c473-538a-4597-ac5c-c1bbd97f3fb7",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "c4bc40bd-795a-4323-a33e-b85513bc5bf0",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "fce41f98-662f-4bb0-b7a8-277f126eb97d",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "633eaabe-1936-4d51-a1de-0bd08c79080d",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      }, {
+        "id" : "bbf5b52a-8fbc-4bb6-b739-44f656db2e32",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "master-realm" : [ "query-users", "query-groups" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+        "attributes" : { }
+      } ],
+      "account" : [ {
+        "id" : "c781f1a9-b3f5-49ec-b947-91c69ed0c6de",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "33ceb12c-9dd8-4d0b-a79c-7bd83e284f80",
+        "attributes" : { }
+      }, {
+        "id" : "7808502c-8ced-42fd-a830-263506d87276",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "33ceb12c-9dd8-4d0b-a79c-7bd83e284f80",
+        "attributes" : { }
+      }, {
+        "id" : "b9f66d1a-9d55-4500-aab7-b029c663a238",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "33ceb12c-9dd8-4d0b-a79c-7bd83e284f80",
+        "attributes" : { }
+      }, {
+        "id" : "43bda457-4a24-4ab3-a5ed-a40c6a0efb44",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "33ceb12c-9dd8-4d0b-a79c-7bd83e284f80",
+        "attributes" : { }
+      }, {
+        "id" : "eb703db2-6f35-4163-98c5-c4c0ace9371a",
+        "name" : "view-groups",
+        "description" : "${role_view-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "33ceb12c-9dd8-4d0b-a79c-7bd83e284f80",
+        "attributes" : { }
+      }, {
+        "id" : "864a424e-1271-443e-ae10-307a49358078",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "33ceb12c-9dd8-4d0b-a79c-7bd83e284f80",
+        "attributes" : { }
+      }, {
+        "id" : "5e5225e5-6b66-40f1-b8fb-d53dabf00312",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "33ceb12c-9dd8-4d0b-a79c-7bd83e284f80",
+        "attributes" : { }
+      }, {
+        "id" : "1d305c2b-6838-4e63-b924-6471fcc9bf8a",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "33ceb12c-9dd8-4d0b-a79c-7bd83e284f80",
+        "attributes" : { }
+      } ],
+      "swg-realm" : [ {
+        "id" : "8a0f7db0-2c1a-4fec-8c75-cc8365ebf12e",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "94169ea1-0b48-41ee-a0ac-b2cebcb8beb9",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "7ac18d57-5dc9-4497-9abb-ff6e91454e36",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "3493e1db-e049-4b6d-8361-d20fb40d7eed",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "swg-realm" : [ "query-groups", "query-users" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "cc9df2e7-3215-4421-b1d7-31c8e7157992",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "d406d928-1695-498a-9489-aaebea2bb363",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "938fa61c-e9e6-4171-aae5-b991139d7c60",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "swg-realm" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "54a31c62-6df5-4a71-800f-4804a0c79752",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "6e9a2fb9-d15b-4291-a398-caa6551a514e",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "aa7c0e17-b138-4e3c-a578-bd322ab5e137",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "6e1b8da9-452a-455a-97fe-ab9f2889a2d3",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "01446df1-9666-41b6-b638-31a50880e88a",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "bf7875ac-5f55-4073-830b-4367a1da7d42",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "9c41ed97-4553-4cbc-849b-4d892e1e0bff",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "ad7b7c73-a098-4b45-81dc-88bf1231d002",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "56e77e18-51b1-4cde-9c53-f356817754c8",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "6f6359d4-8822-404a-ab39-6946b8304670",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      }, {
+        "id" : "1c623ed3-7e77-4870-a955-7f296663b916",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ ],
+  "defaultRole" : {
+    "id" : "eb36b67b-0685-47ab-95e2-684234293438",
+    "name" : "default-roles-master",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "f17ca52e-0f6b-41ea-9d4c-236688d89f6a"
+  },
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpPolicyCodeReusable" : false,
+  "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppMicrosoftAuthenticatorName", "totpAppGoogleName" ],
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "users" : [ {
+    "id" : "94de1b96-9157-4080-9066-782110f74230",
+    "createdTimestamp" : 1695479485789,
+    "username" : "admin",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "credentials" : [ {
+      "id" : "4e024e7f-7e3f-48ed-991b-24d46a21d628",
+      "type" : "password",
+      "createdDate" : 1695479485866,
+      "secretData" : "{\"value\":\"uQt2ZSs9fbswGdjzRIOKGw2F7kOC1ByXgsIh6eHx3Zg=\",\"salt\":\"3uiSKM7N2xXX4ZZAmAY0IA==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "admin", "default-roles-master" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  } ],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clientScopeMappings" : {
+    "account" : [ {
+      "client" : "account-console",
+      "roles" : [ "manage-account", "view-groups" ]
+    } ]
+  },
+  "clients" : [ {
+    "id" : "33ceb12c-9dd8-4d0b-a79c-7bd83e284f80",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/master/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/master/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "f4c08302-abe7-4f69-92f5-6db2ac1816f4",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/master/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/master/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "5e69b5a0-e40c-45ac-ba55-03b5c796f93d",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "9da657f3-e3cd-460d-b333-27547115c12a",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "6aac5c5b-ab72-468c-bdb2-4e7edbd94c06",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "0f40d8ba-605e-49b3-89d1-89b132ef8bf2",
+    "clientId" : "master-realm",
+    "name" : "master Realm",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "32945d20-e699-48af-803a-942870318ea2",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/master/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/master/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "81c8620d-9acc-481f-bdd5-1b7f032f19b9",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "f432b87e-5c8c-4153-af59-d2ada0527e48",
+    "clientId" : "swg-realm",
+    "name" : "swg Realm",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ ],
+    "optionalClientScopes" : [ ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "24cbbdf2-094d-4dfc-b694-0008dc755d78",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "e82eb5a3-359f-48e9-b1cc-0a2298d6bd4f",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "605960d1-5f65-4547-9902-d6f9497fd34e",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "54bb55f6-3981-48b1-a952-377e44d02da3",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "3b0550c3-f9df-4f64-9b7f-6a0385a39866",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "8273b076-9141-45cd-85ca-14bf3b7f4c79",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "6415023d-54d5-4abf-b35c-c99fa704c1d2",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "274064a3-d2fe-4fe7-b869-4e178cc3bc8a",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5883ceb0-c7c2-4bdf-8573-8bd2b08ada79",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "634a81ad-44cd-42e3-b7c1-9deb42787e18",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "1697e4b7-e30f-4d4a-879a-72a9406c228f",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5be62aea-e0c4-4ebf-a43a-fa4561a34070",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0c43c686-93df-49fb-bdfc-031815c3c6d0",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "eacf0890-dfa8-421c-9d9f-63edff632f74",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "9184222b-8e76-4df2-bef1-2c680de7c8e0",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d5f0ffc3-a8b8-4b30-9425-20a20deb6c9b",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "bcecabd3-0aa1-4da9-9866-7bb5e3072164",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "4f884bab-479d-4deb-9e78-c1424a9b8f6d",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "long"
+      }
+    } ]
+  }, {
+    "id" : "5aecbe3d-11cb-4f53-8222-d2482c7844b6",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "6d762c03-4022-4816-989f-78aac14a2bdc",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "60472ec0-9337-4333-b515-6d4e20167735",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "bbc90ac0-711b-4116-98e6-583bcfe87ede",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "f43ae32a-836a-494d-a7f2-9af7b890c1c2",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "9e4042c9-9649-4800-a683-be2331cfcc3a",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "fe64a0f0-64e4-444d-9287-7af2aacb1e8c",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "424d5f78-7ad5-4619-8d13-2fceb3ed2683",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "22263c6a-3b6d-4f33-9981-ed46cd23ec0b",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "23be7f19-da63-421c-bedc-1521d91efcff",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "7732df50-5610-46a9-a382-45f34d104b69",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "ba3921f5-1cef-45ee-bc25-0fbbf647df7f",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d30548da-bd66-4daa-b426-df17a5754bf2",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "a7056e93-491a-4aab-8fc3-5c292e8c70af",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${rolesScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "76e059b9-56dd-4da8-8bde-97ab9e18e926",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    }, {
+      "id" : "9d7f7b23-6f4d-4dde-a80c-e2cefa9a8c6a",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "dd3b9c39-3efd-4452-8b06-63819adb20f2",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    } ]
+  }, {
+    "id" : "6ce9ad65-88c8-4f5c-b1ba-62f65ca76bd3",
+    "name" : "acr",
+    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "22141dd8-ba1f-4acd-bfe0-3569629fe5fc",
+      "name" : "acr loa level",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-acr-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "role_list", "profile", "email", "roles", "web-origins", "acr" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "referrerPolicy" : "no-referrer",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "xXSSProtection" : "1; mode=block",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ ],
+  "identityProviderMappers" : [ ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "18a68e3c-6a92-484b-b38e-9ace22ba11b8",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "d01e95f8-0b2c-4e38-b7c6-f61ab3c1bcce",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "ba7e3010-4bb6-4045-b8d1-8d16f8b712f5",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "fc0812ca-a893-4527-a5fa-ce4bb161b93f",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "78d297d3-19ed-4a8e-8478-3319668cc37b",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "24172b17-eea7-4089-8641-a585f1b49a50",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-usermodel-attribute-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-attribute-mapper", "saml-role-list-mapper", "saml-user-property-mapper", "oidc-full-name-mapper", "oidc-address-mapper" ]
+      }
+    }, {
+      "id" : "f64c9949-1c0c-4c18-9374-7867b71dd43d",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "67ea94ce-3c8d-4dd0-80d2-ac2c1f0b31ae",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-user-attribute-mapper", "oidc-full-name-mapper", "oidc-address-mapper", "oidc-usermodel-attribute-mapper", "saml-role-list-mapper", "saml-user-property-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper" ]
+      }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "612abc16-4e82-4a7a-8806-c375e287dbe1",
+      "name" : "hmac-generated",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "5766d6ff-cbf1-47f7-ad46-cb7677d9ea2d" ],
+        "secret" : [ "mw2r6Xl-HTk-OKcJyKEUlebAeAkYSC6Z7t4ZUS7gii9n7K-gZkNt90o7IhJuxIWWgyJPqmeoyK7l5pGLGsEb0A" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS256" ]
+      }
+    }, {
+      "id" : "5cfccb00-08ff-4a21-9114-57910464868a",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEA4OcbJuOj+fxJop4arn3Ve9TO28NZyI1L1yEtAK3PHdhakHHwTZ3ney1OMDxTzGxlXdP7PmWPlp2RRqyH/7cUw1Op69QL7Pje8+3GeQYUghp9BlazfI/4sX2l9OSHzPbck8eY+xYAad7cqK+OZO5FolqZdUJMZzB5VPO1lhCrBrV0xFdwy6TEMUKFKrwKdqAeJTOqxCvVJ1BjaozDSqSlWZuVK0dPsSvrtpGapCU/sWvrzDkutzWXUueuaL0UFTljYQr893Ex+lOmder3q/91bn3B0rkV3iseFY/UXnwr4AaaOpNJ1kffhFv0xrscuI84cBmscN+fRg94Hfq7LF13ewIDAQABAoIBAFrTKgVuCCIkDw6zn93Y5naQTgu1HBSgb0DNXpG4H30TixtrUBrgSoPVm45iRos3OUaHnZ6owDCYqHssoO2Vn7Z0Gpqo8zn7lXpYC3+Dg5O5I8WEDQ8gS1ROhE9eXTNafGDXygGYdIlM3brnzu8WxJtY0EFpCVbg3hb/JtWYHKFjs1cepZlrS0K+6NtDh8muW5WGV0UbW5rbI37NbEhl+i0bqwmof7NM7vkj59mTgGFACEpqhht32KhUlBRIxpo7qD4hESN4YXV7aLSmBAznxMX1+OmyOF5qirtOYMXoS+U30BvEnPMRJAUi8xp/rwnY35ws5i/Po+GDRLVGw0lgGs0CgYEA/M8kUHCEdpnfytglqdg736TgHDM+/xXuykiLLfIQSt/pMZoV5mx2njQyU1LeuZ/6HAhdQbgkpfx0TV1IGyHeb6jk0RWK4kQ/9ZE36AV4ZGOMqTLIPwo4mggChXYK4gqMxoN0BYty5yJXOMIjCS5hKgeSmj0VR52ThZ/9pRzQRmUCgYEA473Lj0fft6VwNKLHfBd6B3SjRVSbBLeAREBfxj4lh2Eu4Pgl2pNCFbtCCJc/oKfb+Q2XHpVCDKCTDYrgJCS+9RNYIfZ6We1FI+8V7/py6XcOER4ApzuION6HDdthBp0t51DqFuqX7PO3nMkdSrs5x6cZgEx3hhIWlfugWXaEeF8CgYBE0GGTH71+xw26mjFOVRSfILL8GhrotmCkYTC5Ve2HZAGGxel2KknzcEPOmH0Vy+z5mnFABU68e8ZwlJafBA4XGMMIArQmOOur/VZZarvFn69XEwKc3jxf+RQund4Cf1qoYnm/VKD3N0rEoVuGEUDTfvIx17SmJMdWFSGmwvwSXQKBgQCupZP/Uuz7VoGPu+0i+pX4NbgnqNQgb+CLdpp72pjJEvvyRhoxXpBlPe9Ly0FeIJwOiB+FsoyuRk2/KursjMlsA+OoV+5IHC7TebvnBrcs1sIQ2mNB2+OBSRVkyQHFIrBbHbAG1uyfJ998+rXd42pR85EY1IssY56ycf7r3HmGHQKBgHX1NPE5tRkmqxY52KKOwCL6xG/MTB+4eiaW74K7aJveEFz3PA1yH0R0jXi5iyVeu7ZMJETYC+YCGjyJDu/iZVNR25BoKOWG/zcGqVqhNH+yADyc6FyIMzVNDpOeGz02mmlzfXl8XJwLtDDr8VQ7zNrChUoAaFhfxcxKhyyyZEp0" ],
+        "keyUse" : [ "ENC" ],
+        "certificate" : [ "MIICmzCCAYMCBgGKwnPQ9TANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDDAZtYXN0ZXIwHhcNMjMwOTIzMTQyOTQ0WhcNMzMwOTIzMTQzMTI0WjARMQ8wDQYDVQQDDAZtYXN0ZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDg5xsm46P5/EminhqufdV71M7bw1nIjUvXIS0Arc8d2FqQcfBNned7LU4wPFPMbGVd0/s+ZY+WnZFGrIf/txTDU6nr1Avs+N7z7cZ5BhSCGn0GVrN8j/ixfaX05IfM9tyTx5j7FgBp3tyor45k7kWiWpl1QkxnMHlU87WWEKsGtXTEV3DLpMQxQoUqvAp2oB4lM6rEK9UnUGNqjMNKpKVZm5UrR0+xK+u2kZqkJT+xa+vMOS63NZdS565ovRQVOWNhCvz3cTH6U6Z16ver/3VufcHSuRXeKx4Vj9RefCvgBpo6k0nWR9+EW/TGuxy4jzhwGaxw359GD3gd+rssXXd7AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAKhBh45kAlpQU+0TciNK3gVc/ZThp95/3bnXt9mF4MA8PSHr3aXa/vehtyevduZGLsQbYVelRko7xcGhs+wnUkNWm3DMogyXLvSboNYfUEZDql8zncuIpKKqTwhvWFh9nXUUHG5uA5jzk00ehkKsH2MRa4lcQFY+7ZowJtMZsUU0r03uC5HU8dHUWF6TU3YNVLubQ1jwdABuYb1AvR2cVBCsFRb7QRZCFfq/z7difqG77kn0+snkLFF5luNyAfreHO3kMrRjM06RjpBcdIgiB4m7cyBvtK3Ztsj+eCzSbC0vNB40au0RskAw08CIEAFKgO3Sn2CMu02SGVyaeE76y/o=" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
+      }
+    }, {
+      "id" : "f25ee58c-7502-4190-a45c-c5cb3022f0da",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEA2YXogYkDJcsR4HsXBv6Ero6gLRXSYcE8kyFYv/uOVqRzZ25BHGmeFXeh1OMDidIvONRJEkPrw2JXHnhQc49UxE1yZdFbUmbmab/htEXa5aF94VMP75BXY923VS+AUEFE61lpT7kuptJmTFdrGqz9SpFAKXl6zyCRvER//U/0ZLxdJhQeZPfy3yF0JePCjJmjG+a48E+YQS9tQAFd1KyPzgjWCW89lPcmHtTVgfrMSSkLxl7krnnDaGJe/L7NqAMV+bvILyz3YnADRdtGZKIE0/GOd65hziU4aYO4F/1rVdShV+yRRNvRPER8Rw66rpY3n794cCynMovGsmzTj45OywIDAQABAoIBAAjr9R1bAUYLjjAm3ErtJYQDVY6D1p0rz9A5DerR5oSnOhSD8Se5LUK0JW8V4I9Gj6lFC7o0Dvd0kR4u0R3sQw3KH2cNrzEyB0FPHXLHarMAbKlRPtYUlYEDFwHncNvZ0XnVsPwUHFW7S3bWHw55CeqFCpyo3uCf9VpDdPxuyxdWjx/zOs3EaAogS2DdRgFrp9O4q/II6PPVeFqodGi9qUc96rVmvTLv1FL+k56sysat1NPcKjgQzTPKrMJLofU1gZZItHp7310EwIacBWEWbqAay0fyD1D25fddkOjwJ8GIf1pJ6vCNQjJrbWKndZIr8mKVhyXjTA/s9ecJPje4BAECgYEA7CusIMzpiqv+2pREjaY31KQtNzEpqJF7jlxZY6D9uXkOr4vqnTGABc09jZoKLSWBuPk3NWF/iogr7ln2jjzzTL2huW9IiCd3iGK2DuTfmZFAxL76doSoZPRkJF9MZ6/FAYad09IdiCe6UqqHl1/N+wg8SrzZFM40G+kwvwyXMicCgYEA68lribCDL/VjmXVejWe/ZuhwZUxmaea1wey40/4nBqB7fQgL/3eO0M/KdeHOMp5DLhGhxcFC3QKCk/jXFKvf5paM15a3TmIynmBtN8ZA7Clpm78NIdsuc590H0rgL62n674jk07qNtM9/ZqK7Q6jOzU8KAq2bwmUEIAsV3e0eL0CgYAmkOMk4BFrEbcmXnvrXa9UTBMOJjsVSdyRXMdEG7ATL4+UXxbK4KB1UhSxIOx0fuF2IUxArVE0gBQcchhvFcjtSTI1o9SGV1uPq/7q47kXzL504nLoE7Wj9ry7q8xASlWzcBYp1u/3ofUtNqe5sm1ihu/BjKEuYpXj0Oqi6B1wlQKBgQCT7BI+GHHE9aLdlGeUOOE4U1yoAG1DxQyEM9mkjY64NpgiUZkNVVlQoPu4RshQsz8cOM2PvfYPp1J6OKPegRF/nTWQzyoCz9JHz+DVG9iBEF4D6rD3a4VR3lhAhX3uC3kMiYXSFbEUYiRC5OCBZix7qaMqz8WyFYVBcNfgq+WZ1QKBgA1YLzQn6Yfp4IuLlRMKNfARAhPSP/qqbYZeFDg3YsCpRzZJZcrovAUhVmvpFTtwRs1OEsO7zNiFJBST+XVZZqJrzSF+oCblZwMo/8DQgYQ1Lwqsg+07Fr1et7YilOlFLxw+QRzV345WgA3tAs7308bLWQB3oE5L5zWTPdSDZr5w" ],
+        "keyUse" : [ "SIG" ],
+        "certificate" : [ "MIICmzCCAYMCBgGKwnPQQTANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDDAZtYXN0ZXIwHhcNMjMwOTIzMTQyOTQ0WhcNMzMwOTIzMTQzMTI0WjARMQ8wDQYDVQQDDAZtYXN0ZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDZheiBiQMlyxHgexcG/oSujqAtFdJhwTyTIVi/+45WpHNnbkEcaZ4Vd6HU4wOJ0i841EkSQ+vDYlceeFBzj1TETXJl0VtSZuZpv+G0RdrloX3hUw/vkFdj3bdVL4BQQUTrWWlPuS6m0mZMV2sarP1KkUApeXrPIJG8RH/9T/RkvF0mFB5k9/LfIXQl48KMmaMb5rjwT5hBL21AAV3UrI/OCNYJbz2U9yYe1NWB+sxJKQvGXuSuecNoYl78vs2oAxX5u8gvLPdicANF20ZkogTT8Y53rmHOJThpg7gX/WtV1KFX7JFE29E8RHxHDrquljefv3hwLKcyi8aybNOPjk7LAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAL/056S9Op5xYnEzyStsy3/5Taa9J+yl7CVeMEMEar0QbYjFcIRLhEzsWj11CRU2RzFNgP0MvRzGNJoMGahC31iCL1ECmbWkEkj/n0DXhKt+ayrCE7aDx1ZEwFtvdWi/PfaAtDOT1uOYWfjdpTqTg5aCT5cynUeZJbQbaKy3KnQmDaXXy3ILDKFS2CFWyBlnfEshV06QiEHVHfrA+yWK3Ti/ozynyTDbBJ3bA0uIswJ4ZiekdrJ/I3sg2h7AXf7o1DA18Cid2WxW1BaLVBbVhnAl62Tlxrp8shCtlJ/ofBpq5qH0tGCdt1a/5X+YNsYEI2ZZ8UN3h1HGEMwcz+eLjvk=" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "da6e8b3c-9554-4ea0-b954-50903d301ee5",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "2d87d100-0411-4c88-9ebf-fb6fc6d4df6a" ],
+        "secret" : [ "Ai76Heh1yU_vX9nEx5XEJQ" ],
+        "priority" : [ "100" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "id" : "53d1d3e0-f28e-42e7-861a-f41641e09752",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "275201ae-d416-48c3-80d5-3e2abffe494b",
+    "alias" : "Browser - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "939a76a4-df6a-4d2f-8c92-a3c72cd3b3cd",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "87f54495-9aa2-4258-8e6b-c1b2c1828c27",
+    "alias" : "First broker login - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "18ef3a2c-d335-45bb-8552-9d3eb4ebe8e7",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "88b387c2-dbce-41b0-93c2-2da208192597",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "94c49e55-f74e-4f4f-a1c9-4269d00a26e3",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "444f62ec-bc7e-4f48-84df-f25dc668b48e",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First broker login - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "d999ac77-641b-440a-9ac1-6358e068b6f5",
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "8488838d-8463-47e5-9aaf-f702ccc770e6",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "ce1509ab-ceea-4f99-80ac-7c5698b5ed4b",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "b25ead34-e25f-45dd-8f28-d95b299b6cc7",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "4df8b554-db52-43fa-b616-5a5ffd7733dc",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "566bf104-df64-4aeb-a7f5-5bf9d73c4808",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "3f2b767a-d722-4f9d-874d-a1b700945014",
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "b43114fe-f621-4cf9-a20a-24512ecfa05a",
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-profile-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-terms-and-conditions",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 70,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "e0249097-3287-4710-95d0-7b170879e38c",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "aac5f2d1-c5aa-4092-80e6-8472f3d0f83f",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "d2ba5eeb-afcd-4581-a17e-f6118573b242",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "66806bd9-fc7c-4353-b570-530083766505",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "TERMS_AND_CONDITIONS",
+    "name" : "Terms and Conditions",
+    "providerId" : "TERMS_AND_CONDITIONS",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  }, {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register",
+    "name" : "Webauthn Register",
+    "providerId" : "webauthn-register",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 70,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register-passwordless",
+    "name" : "Webauthn Register Passwordless",
+    "providerId" : "webauthn-register-passwordless",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 80,
+    "config" : { }
+  }, {
+    "alias" : "update_user_locale",
+    "name" : "Update User Locale",
+    "providerId" : "update_user_locale",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 1000,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaExpiresIn" : "120",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "parRequestUriLifespan" : "60",
+    "cibaInterval" : "5",
+    "realmReusableOtpCode" : "false"
+  },
+  "keycloakVersion" : "22.0.3",
+  "userManagedAccessAllowed" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
+  },
+  "clientPolicies" : {
+    "policies" : [ ]
+  }
+}

--- a/keycloak_import/swg-realm.json
+++ b/keycloak_import/swg-realm.json
@@ -1,0 +1,1946 @@
+{
+  "id" : "c43b36ad-2af9-4f56-a369-b6f8d4eff15a",
+  "realm" : "swg",
+  "displayName" : "Star Wars Galaxies",
+  "displayNameHtml" : "",
+  "notBefore" : 0,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 300,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : false,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : true,
+  "permanentLockout" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 3,
+  "roles" : {
+    "realm" : [ {
+      "id" : "e4f5b01e-e788-4ed8-8217-f528903606db",
+      "name" : "default-roles-swg",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
+        "client" : {
+          "account" : [ "view-profile", "manage-account" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "c43b36ad-2af9-4f56-a369-b6f8d4eff15a",
+      "attributes" : { }
+    }, {
+      "id" : "d5f85830-2acd-4436-b7e7-83675db9177f",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "c43b36ad-2af9-4f56-a369-b6f8d4eff15a",
+      "attributes" : { }
+    }, {
+      "id" : "6da84667-9006-4bb6-9a75-781e367dc6d1",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "c43b36ad-2af9-4f56-a369-b6f8d4eff15a",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "holocore-localhost" : [ {
+        "id" : "d13d06d3-2720-415b-8932-94ceb1d6d769",
+        "name" : "CSR",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+        "attributes" : { }
+      }, {
+        "id" : "4cbd46d1-3be1-4b69-b2df-53adac5b0f82",
+        "name" : "DEV",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+        "attributes" : { }
+      }, {
+        "id" : "dcef8e6c-fa2e-41f3-adab-113910d9f623",
+        "name" : "WARDEN",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+        "attributes" : { }
+      }, {
+        "id" : "2761ce21-d61a-4a47-9c11-c4da72571d73",
+        "name" : "QA",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+        "attributes" : { }
+      }, {
+        "id" : "32c25515-96aa-4d3c-8174-737f24aec7bc",
+        "name" : "LEAD_QA",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+        "attributes" : { }
+      }, {
+        "id" : "4dc4d8a2-1e3b-443f-8a43-afa2cac6e926",
+        "name" : "PLAYER",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+        "attributes" : { }
+      }, {
+        "id" : "8ea654c4-4633-4592-a66d-70b3931c73e9",
+        "name" : "LEAD_CSR",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+        "attributes" : { }
+      } ],
+      "realm-management" : [ {
+        "id" : "5e724dc7-6068-493c-a30f-956dcb42203a",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "a0c7b888-f536-413a-a024-f0a915ff415f",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "f8d30bc9-753b-412d-b8f2-b38a6b12124d",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "26ed4700-c3e2-4c4c-ad90-d4af68d1c99f",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "94c75ce8-9590-46fd-8665-9de3d8f585ef",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "manage-users", "manage-identity-providers", "query-clients", "manage-authorization", "manage-realm", "view-authorization", "manage-clients", "query-realms", "query-users", "manage-events", "view-realm", "create-client", "view-identity-providers", "view-clients", "view-events", "impersonation", "view-users", "query-groups" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "5810c2d6-973c-4ea8-9eab-485c52a8fc85",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "9dc94cd7-6692-4aaf-a3f3-8a3faabed5e8",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "b9cebc05-9299-4d42-bacb-d5a57c821a3e",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "d107aa45-8b93-447d-af91-604ae2c4251b",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "6e28ffaa-7704-4ab3-a861-c037a43e9f5d",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "1c4046f6-740b-40f8-8e6d-4074662c0fc4",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "24eeb4a8-2a41-4acd-8ed4-37e382e7aaba",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "248e75a0-11c1-431b-9461-8b08655d524e",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "c9b586f1-0c7c-4be2-9232-58347d0e0069",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "61ace48b-2cec-4578-b1e0-fa009f8683ac",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "26e1a829-5ed5-4fec-853a-dc492aac4cb5",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "8803c1f5-1fce-405f-a906-af1a9977d743",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "2dbcc387-93ba-4322-9090-89f0b4ead057",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-groups", "query-users" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "43582d17-16b3-41b6-90d2-06db182034dc",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      } ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "088c8a3d-7d75-4e81-9592-7b13c969ddfe",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "30449f8b-4992-4a88-8ff9-7936a12bd4a2",
+        "attributes" : { }
+      } ],
+      "account" : [ {
+        "id" : "88c7220d-435f-4954-bfa2-deaf0d94d5a0",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      }, {
+        "id" : "ba885667-47ba-4b41-bb5c-c56a8c058fe8",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      }, {
+        "id" : "4665ffab-4fe9-4132-8584-5654f6dd1da2",
+        "name" : "view-groups",
+        "description" : "${role_view-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      }, {
+        "id" : "7c5bc6b7-3982-48fc-9727-a31b8cd70485",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      }, {
+        "id" : "1a9181b0-7f07-477f-88b2-ecd544bd4307",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      }, {
+        "id" : "9030c821-19c4-4d84-99a3-11bc7071e8c7",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      }, {
+        "id" : "6805e67e-380c-4b72-b05a-2de26f2bbadd",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      }, {
+        "id" : "382ef260-fe6c-47cf-8ddd-098478f8ab94",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ {
+    "id" : "3bf397c2-8fa5-441a-8090-dd4c9f0c96c2",
+    "name" : "admins",
+    "path" : "/admins",
+    "attributes" : { },
+    "realmRoles" : [ ],
+    "clientRoles" : {
+      "holocore-localhost" : [ "DEV" ]
+    },
+    "subGroups" : [ ]
+  }, {
+    "id" : "54f68ac8-fd28-495e-a647-67d5a825e027",
+    "name" : "players",
+    "path" : "/players",
+    "attributes" : { },
+    "realmRoles" : [ ],
+    "clientRoles" : {
+      "holocore-localhost" : [ "PLAYER" ]
+    },
+    "subGroups" : [ ]
+  } ],
+  "defaultRole" : {
+    "id" : "e4f5b01e-e788-4ed8-8217-f528903606db",
+    "name" : "default-roles-swg",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "c43b36ad-2af9-4f56-a369-b6f8d4eff15a"
+  },
+  "defaultGroups" : [ "/players" ],
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpPolicyCodeReusable" : false,
+  "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppMicrosoftAuthenticatorName", "totpAppGoogleName" ],
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "users" : [ {
+    "id" : "bafeb644-9282-42a6-aef1-a0046b3e462e",
+    "createdTimestamp" : 1695489511694,
+    "username" : "banned-user",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "firstName" : "",
+    "lastName" : "",
+    "attributes" : {
+      "banned" : [ "true" ]
+    },
+    "credentials" : [ {
+      "id" : "acc3c715-d247-4110-a25a-69f7bcdaec31",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1695539455116,
+      "secretData" : "{\"value\":\"Tqr5HP9OSdzJDnz3R9Hfd9ChPxZ2SV89ZoL3YNB9JnY=\",\"salt\":\"tlV9I73eZMtBIggeRuIq9w==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-swg" ],
+    "notBefore" : 0,
+    "groups" : [ "/players" ]
+  }, {
+    "id" : "5a9e50a3-64b5-4650-a36d-c902fefa904a",
+    "createdTimestamp" : 1695477065617,
+    "username" : "user",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "firstName" : "",
+    "lastName" : "",
+    "attributes" : {
+      "banned" : [ "false" ]
+    },
+    "credentials" : [ {
+      "id" : "069c93a4-889b-4e5e-97a5-99239e4d8925",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1695477084200,
+      "secretData" : "{\"value\":\"o58/EBHmYZ6XW0Xk5NjkxWwiSLOWwjSC/VTew/HogGE=\",\"salt\":\"rboqEuRe8PnQaEv6sw1I2g==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-swg" ],
+    "notBefore" : 0,
+    "groups" : [ "/admins" ]
+  } ],
+  "clients" : [ {
+    "id" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/swg/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/swg/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "3a1ac9dd-9271-46e4-8133-5b3d25145af3",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/swg/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/swg/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "3a09ba3c-f018-4329-90c4-d73cb046eaf0",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "b2aa2a50-0399-41f1-af95-41635aa88d51",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "30449f8b-4992-4a88-8ff9-7936a12bd4a2",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+    "clientId" : "holocore-localhost",
+    "name" : "",
+    "description" : "",
+    "rootUrl" : "",
+    "adminUrl" : "",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "nrrtW0NqbNWXn62ii6218QHWbEhVGXaf",
+    "redirectUris" : [ "/*" ],
+    "webOrigins" : [ "/*" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "oidc.ciba.grant.enabled" : "false",
+      "client.secret.creation.time" : "1695477159",
+      "backchannel.logout.session.required" : "true",
+      "post.logout.redirect.uris" : "+",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "display.on.consent.screen" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "5fe816ae-53a3-44a1-873b-4bfb7834a81d",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "false",
+        "access.token.claim" : "false",
+        "claim.name" : "roles",
+        "jsonType.label" : "String",
+        "usermodel.clientRoleMapping.clientId" : "holocore-localhost"
+      }
+    }, {
+      "id" : "042e751d-e8f5-4072-96ba-f87163e64d91",
+      "name" : "Banned",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "aggregate.attrs" : "false",
+        "userinfo.token.claim" : "true",
+        "multivalued" : "false",
+        "user.attribute" : "banned",
+        "id.token.claim" : "false",
+        "access.token.claim" : "false",
+        "claim.name" : "banned",
+        "jsonType.label" : "boolean"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "d9324edd-9e39-4b66-89dd-b15a8f2734aa",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/swg/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/swg/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "0804a758-0b50-4641-98e4-c777b78cd070",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "432948a3-e509-44fd-a9fc-9f41d3ccc9d3",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "25b17b22-a52b-4376-ab04-f138e1e0bd57",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "4032a79b-409e-4575-8fa6-3b14c2bf049d",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${rolesScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "66d5488d-bb85-4ce4-bb26-204fb13f6d1c",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    }, {
+      "id" : "88fb06a7-8099-43d2-95a9-70c10cb3ff5a",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "168df763-c619-413c-8d00-8b8e00625e9c",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "userinfo.token.claim" : "false",
+        "user.attribute" : "foo",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true",
+        "claim.name" : "roles",
+        "jsonType.label" : "String",
+        "usermodel.clientRoleMapping.clientId" : "holocore"
+      }
+    } ]
+  }, {
+    "id" : "6c91c5ca-4aab-4138-9030-61dcab5fb5aa",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "42bdbb02-2a6f-44bc-8834-01566e002bfb",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d15aa7e4-b7a9-4652-994b-56f0610f1f3f",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "632998cf-e77f-4512-a082-e01d8e87f3dd",
+    "name" : "acr",
+    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "864bd5fa-8dfb-4e54-a3ae-f8c33c65e530",
+      "name" : "acr loa level",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-acr-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "0aa6f94c-97ea-4cd9-874f-50cab2b5c416",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "e33a30d2-a329-4bcb-98b3-eb567e8db9a4",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "ff151617-a0e4-43a1-8195-5d4649bddf35",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "5035352a-8538-4b22-ab75-d17bfe79bc07",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "16dfca22-1c08-4d6e-b59d-1960f3107e91",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "ccda6aeb-2acf-4ce1-8f10-be641d6bcc8e",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "857e1f90-bfc2-456d-b734-f6343e251a3b",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "371f3ffb-45b6-44f0-beda-31908098b7ca",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "faa66018-e1e9-4a80-8196-21315532695c",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "f073e1ae-d415-43e3-abdf-348fce616e05",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8a951015-2552-4df9-81c5-ad8f5a12f2d6",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "id" : "aeefd618-add1-4b40-b958-729dda3c18bf",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "3734ebb3-e91c-434b-a4c4-b2b9bf4497da",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "9bc62d20-1b07-4c77-bfc7-da6bc2550dec",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "79990067-cebe-462c-bef1-318e81b52660",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5b1b5cbc-0b15-4a08-a22b-21a3d3ef9258",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8c1bfdac-d4f9-4d0a-98ff-2258052f5f77",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "long"
+      }
+    }, {
+      "id" : "379465ac-4c89-45da-b67a-8b33f4aabc52",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5b6f2c7f-a026-4b2c-aee2-a4d0397525d5",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "732c20fc-98fc-41b1-a7dc-579796b94ea3",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "cb9c05de-2c4b-4a90-8962-8b2314f2d74f",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "fa049728-780a-411d-ab56-0b5cff044feb",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "3299c4f5-cc07-4b69-bfc9-0ca04d470a7b",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "cd632e98-9df9-41a1-b277-c5f978e0ac8f",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "681af47a-b940-405d-bf87-c5bcf6fd2cd4",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c012190f-fa76-4f77-bead-8337361a2a11",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "role_list", "profile", "email", "roles", "web-origins", "acr" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "referrerPolicy" : "no-referrer",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection" : "1; mode=block",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ ],
+  "identityProviderMappers" : [ ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "bd3d1c48-489f-48f7-b619-f452221011f2",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "saml-user-attribute-mapper", "oidc-address-mapper", "oidc-full-name-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-attribute-mapper", "oidc-usermodel-property-mapper" ]
+      }
+    }, {
+      "id" : "942a2c06-8868-4c00-ab59-1f547aa02e88",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "4533002e-e644-4e08-bf8d-fc4635256734",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "3cb6ddf7-e30f-4a5e-b047-0b3fa532efe6",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "00d073aa-56c3-46db-b06a-58a1fc29c770",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "51a7ed62-af76-4b6b-b4d2-2631e1771057",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "1f5d1d91-1113-4286-9c1c-687ff562eee1",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "3ecd403c-d88c-42b2-90f0-3b0f6e6c69c3",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-role-list-mapper", "oidc-usermodel-attribute-mapper", "oidc-address-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "saml-user-property-mapper", "saml-user-attribute-mapper" ]
+      }
+    } ],
+    "org.keycloak.userprofile.UserProfileProvider" : [ {
+      "id" : "8c0ff21b-8051-434f-80a4-9b3ded74e7d1",
+      "providerId" : "declarative-user-profile",
+      "subComponents" : { },
+      "config" : { }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "d46e0fa7-88aa-4e5d-ae9d-8cf57d3d4b61",
+      "name" : "hmac-generated",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "668c0087-a0e3-497a-8b9f-499907997a15" ],
+        "secret" : [ "fuFl_RGKY5Jnriwn2S5eJ7umDVzv6TjUJDAt0eO-0GcZ1BuDkC4J9NzvzXgB2ws3vGfxiHTj23Ug1N38tpY3wg" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS256" ]
+      }
+    }, {
+      "id" : "b28ef11e-2efe-4b02-b65f-e532dec0f6b7",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "7eb8d5fd-2292-4a83-800d-11672e53351c" ],
+        "secret" : [ "P1YtHoFCQmy5CjjpiFZ1Kw" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "28e2957e-1f5a-4378-a552-56d051dcac3a",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEAvL9x8kL2EIXWRKyE4ESlf6yL5T9PEhvd9zSdsUedyMeEbX1empJBpVFyxPy4IW/e+w0J/JWh/FWilwqQrQFviyzQCe5w47Xtx9woDNpeEFfUtPEbYVeeOtiO/JHpel4lEgcB1juKk30Xcaf0Ev107A4uDGb+TQqt+b2afK/pKcO8S8JBOBo4HHy+qPiAkyAaBqpXPYEEnt5t3fv6N7SNzEEm9UWuP1beLHEcRblYYDonc5J2ElZao5sQ/mdytz+hrGi1JF7f4wzZ0Yf9Jf9LZKVofcqCJ20TZ6Nwnn3QX1zcNZvmr8ltSgQfm1tvk7wEsi/50oa8Fw31Mqr/2Xw9GwIDAQABAoIBABACE1xJrkGZKE1rbbBGV4cBj7KMxlxcfVyMW4d/8cjn6w+3igDawLM7D4cs1pe3ZkECn8M1aadTbVZuxfXLtmB7wiqQIjDzQCHVm+v4epvbkdBwK937UWc08MOebcqRa4bLjgNTyh1XhwJ+YnwDKm8kMLxKi+zlfVCTcnklbkVlYs00aGsK5k1y8Kc8IQddW+woWp+UdQi7jwo01MRYyY0SjBx3IAORqUTch7nR33KMpfhFE+HgDpjxHavVg0U4QGSzx4jcwUMWYCwhgcBId+Yn5116UgEFx/2jHLtzIfywKgNMRnnDMWYhcT6hQTs1m2X3zQmytlJmQaQmueffyTECgYEA5hiWKdFCEseTIsoykwP4VkrKV3quliaCUGpZd2VStUYwXlcKLHi5mSXDY3gren0tK/G6byVbrMRI2eIiP2SLFEbQHu6TgnGD1b+HLqxVChS6CvFSUTU4MVVbS4RomVsgIzXkMn/Zg3wqgWgXklYdH6o19Tr+HC7qsURjqvhPiNkCgYEA0f8x6XZR90oT9hKJLpmAEsJbNihII+UqRsp9JQqnVcot5ghWOoZByuetGJnGHuZgtJk9FZrND57ioxXr3EmncaRZL6R0ueMZAjxEfCpv3KIzmtU9F+AV2v11lg3C3DstG5XpVT8qpNOZYcUqelXDEUPy8LP6StWcj+vd46DonRMCgYEAxu7Y3RyraHsdzcVNBmg3S7vrxsgtq2lt30KjSSPT5x/g75+HDz3tEOhiTlx2Ereo10Zt7mw5H1yws5fcDjzKNeSnSSbxZ6Tm22V05bhe6ZFT6+QKTGWbyKNIhDjdCkGLvoV4XuTEVPaD9U/emUlUcq0Ba5zuV8WEaXB8TzPR57kCgYAO3iKKhPYIrBX9thJAWl3W9iu/CdsRr4fuuydhGAAA8u+M+cohGqBN3VlEBJ8iUO1H3BGXFf6uvHEPWt34Gr7gLOKjnOEmyA1dOyceI2MIG/PLYo2QwyzI9Gj+1rqVHRt0eIisoGxEfza81VjMkIXfExCAOj3eToFnLyvmkd3mQQKBgF7ksGo4JR3+JAEKj7lnwkPZqI+SRBOSUE1x/N1fk/aNBomg8SCqJFNekmJWGzXlNC2nC/6ysbiaijTa2Al9/EtCTgI1iAhlQ89DvUyk3TkTaxG2hsUC8Y5nB8OQf7Il+pRk547NLCqXquxi8saGlVeh3Sjzo7DyOMrUshx42b12" ],
+        "keyUse" : [ "ENC" ],
+        "certificate" : [ "MIIClTCCAX0CBgGKwk5aMzANBgkqhkiG9w0BAQsFADAOMQwwCgYDVQQDDANzd2cwHhcNMjMwOTIzMTM0ODQ5WhcNMzMwOTIzMTM1MDI5WjAOMQwwCgYDVQQDDANzd2cwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8v3HyQvYQhdZErITgRKV/rIvlP08SG933NJ2xR53Ix4RtfV6akkGlUXLE/Lghb977DQn8laH8VaKXCpCtAW+LLNAJ7nDjte3H3CgM2l4QV9S08RthV5462I78kel6XiUSBwHWO4qTfRdxp/QS/XTsDi4MZv5NCq35vZp8r+kpw7xLwkE4GjgcfL6o+ICTIBoGqlc9gQSe3m3d+/o3tI3MQSb1Ra4/Vt4scRxFuVhgOidzknYSVlqjmxD+Z3K3P6GsaLUkXt/jDNnRh/0l/0tkpWh9yoInbRNno3CefdBfXNw1m+avyW1KBB+bW2+TvASyL/nShrwXDfUyqv/ZfD0bAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAKtXXejDnu+0QN3H8/kgKk/CgXa8guPa8NDjPo4ngC+L+ADD7kP7yE42gFxrv0nMBSKrAnHwAvdhAY2BpROToSjoca6sTjBohjSm0caGW3RK5iZLc3Yb1DHw++Du5UfjnBsrtdSW7N7RfEn6WfdGytRRGAOES3rmjmQ62yZ7/XpDAX3XFIn59QqBl9Fe7JCshLm3irbw0D595vnGp74LydT27/G6QUQ7H9A3D8frbi/619Q7VRxZBGNP3RdEfGje/UqqMIqxAsJQBrSUurEpn25WBhlg1xPQ7b0i6OQUUqURqoE0OPZ0sfBZ7QxNoHt9yPGbM4MLypCEAz9/r2Id2Yw=" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
+      }
+    }, {
+      "id" : "8a999290-b6e8-48b7-9876-c592f013fcac",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEpAIBAAKCAQEAv5Y04QpyrYgcivikT9wjSyk8olhtq7J82GEZ6ijYiUWBq+YahBpgwf7YRSlE+9EXWykpUGnrJJJRuxMc/HgGc1pC/WR9GjB38QE0Her4ZFndrWj7W5ZC40FmwAAgvK5jtzkhEmJDC9OBWKeDgDUwF2nI79+YavB8rFHCIxUrJMAKfZy4WzG29sLWo0oGDPF9k0SdX2qgvWx3OKv4+UK91UctB15W7MSEH88U4xEAucvVGll46sF9FdAxRysENGETXy2APACoOHmy2i0cs3xh9AVm7rUlLwe5yTTw+/NvYU3mugcoObarr/DSZoPoENEQ3RtnFaQDLd0E/S2RR+DbzwIDAQABAoIBABZNWPh9a94RgykWSqJVQPKF6V4IpzOegnP50bd1a8eHBNJK5flMzMiobuqWJEagD3T4NKv8uHe4ZLU/Q1eMbUvOTRAMO5fp3nx6pGN7L9EWuPxvxRrjQgQMX/anzSfJsSfqCZSHRcDBrUPxtBgfmOqQ0OhDgg2o0wqINe45j50mXkBdAnu75ftmxRm555oKuMtc10pOuz2ywSYGuY9nnSBe5X9AIdp9iqzcabIaNH6jtvUCYeo4HDksKtx+aJq2zftoW7n8QsT5nTvvqiEv/uVldr1R3JXAkV1keY8TkJeEDacwbWOkeLTcHDUw3/yBdAGAp9sqwZ6Ha1SqgqlmeokCgYEA4aWvdXy8ftd0fEwNsbKbZ+7tHjl133NJ5BMwhKRffY7KIrxnGsB4sEEaeRGEPydl2SeEjMM8WTyB3vRuSc5AjA9FJDF0l5NPDEBPigCB3Yjt/t3W/IfoheX8Xaxgec3jivVVNxZbxSLiaM4wTK+npGn83UJw6iAf2TxoFPu1JnUCgYEA2VugQURSVJFfLmYrAOaF6FaauKiW6eDNahS98Wy07P1NOiOVUI3l2EktH61P/9t6B97JjKq5ThYp6Xi2t+DLcLjCXpR2oX/OQ32/tLJNohGeXWb8fyxvdxGAFdNpfreZ1bQMbGvOuYqDHlocVYC5MdQbo/igsxEgd+Obqd6sGLMCgYEA3MEvqw1hi+ZVe9UcAKDwEPpa2Jr2iqlLvOpZKSt2kGvFrb4MUMvERwsqTw+oBfERXyWeM+g9fkAH/ou76lDyLRQzXHlVy4S+bQntxuFAK+/uhs2Zqm18OqMKBsrBh+i5mBT0TXR+S5sZTdeKwTuIEv3t+LkrpqHPBsRmP0ERtJECgYB62H5KZQLjKQZSgwvrBl7IYaowk5g3twZh3jc8K+RVzRPIuDO7w3cUNsd6D8oXIURnDlN7XUI+D+jAO6mJY1OX8dRpAB/MRx+cpYWj6uJVpv+KappqhgK5mPp7W3FUXRBk583duVCtLMvOa79307jXoLm+gtbQXe2r1Mg1ydQaYQKBgQCoz9uJzmOhYikHvntZ6tHG9meVJsLTuoDsOnaGc2XnETl/q1lCiA8u5mcMiFAtwBqZhtXHY5EALpoHlopvXlcP0TQJ34XRyJIBp6NNrdMgQmu+nHR/J/4MVB+4LS97QFITPFJWYK2tU6gJhoy5e7njsSygGM/gR8HquxlkdYSAVw==" ],
+        "keyUse" : [ "SIG" ],
+        "certificate" : [ "MIIClTCCAX0CBgGKwk5ZuzANBgkqhkiG9w0BAQsFADAOMQwwCgYDVQQDDANzd2cwHhcNMjMwOTIzMTM0ODQ5WhcNMzMwOTIzMTM1MDI5WjAOMQwwCgYDVQQDDANzd2cwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/ljThCnKtiByK+KRP3CNLKTyiWG2rsnzYYRnqKNiJRYGr5hqEGmDB/thFKUT70RdbKSlQaeskklG7Exz8eAZzWkL9ZH0aMHfxATQd6vhkWd2taPtblkLjQWbAACC8rmO3OSESYkML04FYp4OANTAXacjv35hq8HysUcIjFSskwAp9nLhbMbb2wtajSgYM8X2TRJ1faqC9bHc4q/j5Qr3VRy0HXlbsxIQfzxTjEQC5y9UaWXjqwX0V0DFHKwQ0YRNfLYA8AKg4ebLaLRyzfGH0BWbutSUvB7nJNPD7829hTea6Byg5tquv8NJmg+gQ0RDdG2cVpAMt3QT9LZFH4NvPAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJ24o5H6Iqk+9MU6MmGP53eMOj4NOgbY5MkWtLYvEWBFqZ8IznwYr4YD0yp33toIjX30abGVs4s6AWTvmGf0FLWXLcW1WNUdlkf0uE2bqpsQXodApQWDqEExBq87Ly/qbpOdRS/JJr7zWwqSzPqEIkbj/7rQnCCv9mPMiZ5M+AtSQg2UH7bpkVejxEabzv9Cgehdqi/3xisvKYS1ZokkFcsGS/Rr98utCjBZBO7bZEwWwBhu848tRqL1ZoLXCoBY6qIaufVB/O4PjpzH5uAj8BnZBpENtOImCK39K4ebsd8+QuYGoFJ1RynG8SODx8+IOtJj0epQ2/+FzjW4NCMRZUo=" ],
+        "priority" : [ "100" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "id" : "608fcd5a-d937-4b5a-ab20-0e5e42d57de3",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "a152f0ef-7efe-4804-a3fa-127b05869b47",
+    "alias" : "Browser - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "d464b263-3e5d-4b4a-ae99-cf23944ce176",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "209bc4f0-49ea-4b5a-a1fe-e665aae0d6ad",
+    "alias" : "First broker login - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "3b6ee3a5-f71c-41d8-94f3-107115d53bf4",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "c4381ac0-3d57-4a45-b2b8-84fbfd2398f5",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "30456245-b0fd-431c-b7e0-afeb1a7638a9",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "e7d598cd-2a6f-4a03-a0cf-6a3ce1b90f47",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First broker login - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "938ef660-b2f3-4862-be3a-f5b6901a01bb",
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "d2e49d48-d121-4e03-a0ee-d1d9762406ef",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "044599ba-aba1-4143-9035-4311953c4ae8",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "87827e43-b4d8-4739-a57c-4da4c7ea8e6c",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "296a770a-1161-4b6a-aca2-0b516881b123",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "e6873ac3-3c64-4e38-af68-22901522eae0",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "eedd4de0-8568-47ca-b346-3ae2823b06c3",
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "d8ab5055-32e9-4b9f-a1b2-1e3e63074add",
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-profile-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "6f05f526-5c56-4984-a034-6b775ed99c17",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "0681d017-10a4-4279-a2d1-2f52e9126d6f",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "f41ecfc7-8ed7-4b14-814d-9d355cae7193",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "c51be89c-45c4-4b9a-bc60-66efd12c5065",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "TERMS_AND_CONDITIONS",
+    "name" : "Terms and Conditions",
+    "providerId" : "TERMS_AND_CONDITIONS",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  }, {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register",
+    "name" : "Webauthn Register",
+    "providerId" : "webauthn-register",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 70,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register-passwordless",
+    "name" : "Webauthn Register Passwordless",
+    "providerId" : "webauthn-register-passwordless",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 80,
+    "config" : { }
+  }, {
+    "alias" : "update_user_locale",
+    "name" : "Update User Locale",
+    "providerId" : "update_user_locale",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 1000,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "clientOfflineSessionMaxLifespan" : "0",
+    "oauth2DevicePollingInterval" : "5",
+    "clientSessionIdleTimeout" : "0",
+    "clientOfflineSessionIdleTimeout" : "0",
+    "cibaInterval" : "5",
+    "realmReusableOtpCode" : "false",
+    "cibaExpiresIn" : "120",
+    "oauth2DeviceCodeLifespan" : "600",
+    "parRequestUriLifespan" : "60",
+    "clientSessionMaxLifespan" : "0",
+    "frontendUrl" : "",
+    "acr.loa.map" : "{}"
+  },
+  "keycloakVersion" : "22.0.3",
+  "userManagedAccessAllowed" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
+  },
+  "clientPolicies" : {
+    "policies" : [ ]
+  }
+}

--- a/mongo_init_scripts/default_user.js
+++ b/mongo_init_scripts/default_user.js
@@ -1,7 +1,0 @@
-db.users.insert({
-	username: "user",
-	password: "pass",
-	accessLevel: "dev",
-	banned: false, 
-	characters: []
-});

--- a/mongo_init_scripts/oidc.js
+++ b/mongo_init_scripts/oidc.js
@@ -1,0 +1,8 @@
+// Values are for the default localhost Keycloak instance, run by the docker-compose.yml in the root of this repo.
+db.config.insertOne({
+	package: "support.data.server_info.oidc",
+	authorizationServerBaseURI: "http://localhost:8080/realms/swg",
+	wellKnownConfigurationURI: ".well-known/openid-configuration",
+	clientId: "holocore-localhost",
+	clientSecret: "nrrtW0NqbNWXn62ii6218QHWbEhVGXaf"
+});

--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/database/PswgUserDatabase.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/database/PswgUserDatabase.kt
@@ -30,15 +30,13 @@ import com.projectswg.holocore.resources.support.global.player.AccessLevel
 
 interface PswgUserDatabase {
 	
-	fun getUser(username: String): UserMetadata?
-	fun authenticate(userMetadata: UserMetadata, password: String): Boolean
+	fun authenticate(username: String, password: String): Authentication
 	
 	companion object {
 		
 		fun createDefault(): PswgUserDatabase {
 			return object : PswgUserDatabase {
-				override fun getUser(username: String): UserMetadata? = null
-				override fun authenticate(userMetadata: UserMetadata, password: String): Boolean = false
+				override fun authenticate(username: String, password: String): Authentication = throw UnsupportedOperationException("Cannot authenticate with default PswgUserDatabase")
 			}
 		}
 		
@@ -46,7 +44,9 @@ interface PswgUserDatabase {
 	
 }
 
-class UserMetadata(val accountId: String, val username: String, val accessLevel: AccessLevel, val isBanned: Boolean) {
+data class Authentication(val success: Boolean, val user: UserMetadata?)
+
+data class UserMetadata(val accountId: String, val username: String, val accessLevel: AccessLevel, val isBanned: Boolean) {
 	
 	override fun toString(): String = "UserMetadata[username=$username accessLevel=$accessLevel banned=$isBanned]"
 	override fun equals(other: Any?): Boolean = if (other is UserMetadata) accountId == other.accountId else false

--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/oidc/PswgUserDatabaseOIDC.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/oidc/PswgUserDatabaseOIDC.kt
@@ -1,0 +1,122 @@
+/***********************************************************************************
+ * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.resources.support.data.server_info.oidc
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.projectswg.holocore.resources.support.data.server_info.database.Authentication
+import com.projectswg.holocore.resources.support.data.server_info.database.PswgUserDatabase
+import com.projectswg.holocore.resources.support.data.server_info.database.UserMetadata
+import com.projectswg.holocore.resources.support.global.player.AccessLevel
+import me.joshlarson.jlcommon.log.Log
+import me.joshlarson.json.JSONObject
+
+
+/**
+ * Implements a user database with the OAuth2 Password Grant flow to retrieve user information from a remote authorization server.
+ *
+ * Based on the OpenID Connect specification: https://openid.net/specs/openid-connect-core-1_0.html
+ *
+ * @param authorizationServerBaseURI The base URI of the authorization server, e.g. "http://localhost:8080/realms/swg"
+ * @param wellKnownConfigurationURI relative URI to the well-known configuration, e.g. ".well-known/openid-configuration"
+ * @param clientId The client ID of the client registered with the authorization server
+ * @param clientSecret The client secret of the client registered with the authorization server
+ */
+class PswgUserDatabaseOIDC(private val authorizationServerBaseURI: String, wellKnownConfigurationURI: String, clientId: String, clientSecret: String) : PswgUserDatabase {
+
+	private val openIDConnect = OpenIDConnect(authorizationServerBaseURI, wellKnownConfigurationURI, clientId, clientSecret)
+
+	override fun authenticate(username: String, password: String): Authentication {
+		return try {
+			attemptCredentials(username, password)
+		} catch (exception: Exception) {
+			Log.w("User authentication failed: ${exception.message}")
+			Authentication(false, null)
+		}
+	}
+
+	private fun attemptCredentials(username: String, password: String): Authentication {
+		val passwordGrant = openIDConnect.tokenEndpoint.passwordGrant(username, password)
+		val idToken = passwordGrant.idToken
+
+		verifyAccessToken(idToken)
+
+		val accessToken = passwordGrant.accessToken
+		val userinfo = openIDConnect.userinfoEndpoint.userinfo(accessToken)
+		val userMetadata = mapJsonObjectToUserMetadata(userinfo, username)
+		return Authentication(true, userMetadata)
+	}
+
+	private fun verifyAccessToken(idToken: IdToken) {
+		val signatureCertificates = openIDConnect.jwksEndpoint.signatureCertificates()
+		val decodedJWT = idToken.token
+		val kid = KID(decodedJWT.keyId)
+		val rsaPublicKey = signatureCertificates[kid]
+		val algorithm = Algorithm.RSA256(rsaPublicKey, null)
+		val verifier = JWT.require(algorithm).withIssuer(authorizationServerBaseURI).build()
+
+		verifier.verify(decodedJWT)	// Exception is thrown if verification fails
+	}
+
+	private fun mapJsonObjectToUserMetadata(userinfo: JSONObject, username: String): UserMetadata {
+		val accessLevel = accessLevel(userinfo, username)
+		val banned = isBanned(userinfo)
+		val accountId = userinfo.getString("sub")
+		return UserMetadata(accountId, username, accessLevel, banned)
+	}
+
+	private fun isBanned(userinfo: JSONObject): Boolean {
+		val claimName = "banned"
+		if (userinfo.containsKey(claimName)) {
+			return userinfo.getBoolean(claimName)
+		}
+
+		return false
+	}
+
+	private fun accessLevel(userinfo: JSONObject, username: String): AccessLevel {
+		if (userinfo.containsKey("roles")) {
+			val roles = userinfo.getArray("roles")
+			if (roles.isNotEmpty()) {
+				return largestAccessLevel(roles)
+			}
+		}
+
+		return fallbackAccessLevel(username)
+	}
+
+	private fun largestAccessLevel(roles: MutableList<Any>): AccessLevel {
+		return roles.map { it as String }.map { AccessLevel.valueOf(it) }.maxBy { it.value }
+	}
+
+	private fun fallbackAccessLevel(username: String): AccessLevel {
+		val fallbackAccessLevel = AccessLevel.PLAYER
+		Log.w("User $username has no roles assigned, defaulting to $fallbackAccessLevel")
+		return fallbackAccessLevel
+	}
+
+}

--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/oidc/TokenEndpoint.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/oidc/TokenEndpoint.kt
@@ -24,15 +24,46 @@
  * You should have received a copy of the GNU Affero General Public License        *
  * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
  ***********************************************************************************/
+package com.projectswg.holocore.resources.support.data.server_info.oidc
 
-package com.projectswg.holocore.resources.support.data.server_info.mariadb
+import com.auth0.jwt.JWT
+import com.auth0.jwt.interfaces.DecodedJWT
+import me.joshlarson.json.JSON
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 
-import com.projectswg.holocore.resources.support.data.server_info.database.Authentication
-import com.projectswg.holocore.resources.support.data.server_info.database.DatabaseTable
-import com.projectswg.holocore.resources.support.data.server_info.database.PswgUserDatabase
+class TokenEndpoint(private val grantTypesSupported: Collection<String>, private val tokenEndpoint: String, private val authorizationHeaderValue: String) {
+	private val httpClient = HttpClient.newHttpClient()
 
-class PswgUserDatabaseMaria(private val database: DatabaseTable) : PswgUserDatabase {
+	fun passwordGrant(username: String, password: String): TokenResponse {
+		if (!grantTypesSupported.contains("password")) {
+			throw RuntimeException("Password grant type is not supported by the identity provider")
+		}
 
-	override fun authenticate(username: String, password: String): Authentication = throw UnsupportedOperationException("Cannot authenticate with MariaDB")
+		val tokenRequest = HttpRequest.newBuilder(URI(tokenEndpoint))
+			.header("Authorization", authorizationHeaderValue)
+			.header("Content-Type", "application/x-www-form-urlencoded")
+			.POST(HttpRequest.BodyPublishers.ofString("grant_type=password&username=$username&password=$password&scope=openid"))
+			.build()
+		val tokenResponse = httpClient.send(tokenRequest, HttpResponse.BodyHandlers.ofString())
+		val statusCode = tokenResponse.statusCode()
+		if (statusCode != 200 && statusCode != 401) {
+			throw RuntimeException("Failed to invoke token endpoint, unexpected status code: $statusCode")
+		}
+		val tokenResponseBodyString = tokenResponse.body()
+		val tokenJsonObject = JSON.readObject(tokenResponseBodyString)
+		val accessToken = tokenJsonObject.getString("access_token")
+		val idTokenStr = tokenJsonObject.getString("id_token")
+		val tokenType = tokenJsonObject.getString("token_type")
+		val idToken = JWT.decode(idTokenStr)
 
+		return TokenResponse(AccessToken(accessToken, tokenType), IdToken(idToken, tokenType))
+	}
 }
+
+// This object could be extended to include the other fields in the token response, but these are all we need right now
+data class TokenResponse(val accessToken: AccessToken, val idToken: IdToken)
+data class AccessToken(val token: String, val type: String)
+data class IdToken(val token: DecodedJWT, val type: String)

--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/oidc/UserinfoEndpoint.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/oidc/UserinfoEndpoint.kt
@@ -24,15 +24,31 @@
  * You should have received a copy of the GNU Affero General Public License        *
  * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
  ***********************************************************************************/
+package com.projectswg.holocore.resources.support.data.server_info.oidc
 
-package com.projectswg.holocore.resources.support.data.server_info.mariadb
+import me.joshlarson.json.JSON
+import me.joshlarson.json.JSONObject
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 
-import com.projectswg.holocore.resources.support.data.server_info.database.Authentication
-import com.projectswg.holocore.resources.support.data.server_info.database.DatabaseTable
-import com.projectswg.holocore.resources.support.data.server_info.database.PswgUserDatabase
+class UserinfoEndpoint(private val userinfoEndpoint: String) {
+	private val httpClient = HttpClient.newHttpClient()
 
-class PswgUserDatabaseMaria(private val database: DatabaseTable) : PswgUserDatabase {
-
-	override fun authenticate(username: String, password: String): Authentication = throw UnsupportedOperationException("Cannot authenticate with MariaDB")
-
+	fun userinfo(accessToken: AccessToken): JSONObject {
+		val type = accessToken.type
+		val token = accessToken.token
+		val userinfoHttpRequest = HttpRequest.newBuilder(URI(userinfoEndpoint))
+			.header("Authorization", "$type $token")
+			.GET()
+			.build()
+		val userinfoHttpResponse = httpClient.send(userinfoHttpRequest, HttpResponse.BodyHandlers.ofString())
+		val statusCode = userinfoHttpResponse.statusCode()
+		if (statusCode != 200) {
+			throw RuntimeException("Failed to retrieve userinfo, status code: $statusCode")
+		}
+		val userinfoResponseBodyString = userinfoHttpResponse.body()
+		return JSON.readObject(userinfoResponseBodyString)
+	}
 }

--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/oidc/WellKnownConfiguration.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/oidc/WellKnownConfiguration.kt
@@ -24,15 +24,34 @@
  * You should have received a copy of the GNU Affero General Public License        *
  * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
  ***********************************************************************************/
+package com.projectswg.holocore.resources.support.data.server_info.oidc
 
-package com.projectswg.holocore.resources.support.data.server_info.mariadb
+import me.joshlarson.json.JSON
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 
-import com.projectswg.holocore.resources.support.data.server_info.database.Authentication
-import com.projectswg.holocore.resources.support.data.server_info.database.DatabaseTable
-import com.projectswg.holocore.resources.support.data.server_info.database.PswgUserDatabase
+class WellKnownConfiguration(authorizationServerUri: String, wellKnownConfigurationURI: String) {
+	private val httpClient = HttpClient.newHttpClient()
+	val tokenEndpointUri: String
+	val jwksUri: String
+	val userinfoEndpointUri: String
+	val grantTypesSupported: Collection<String>
 
-class PswgUserDatabaseMaria(private val database: DatabaseTable) : PswgUserDatabase {
+	init {
+		val uri = URI("$authorizationServerUri/$wellKnownConfigurationURI")
+		val wellKnownConfigurationRequest = HttpRequest.newBuilder(uri).GET().build()
+		val wellKnownConfigurationResponse = httpClient.send(wellKnownConfigurationRequest, HttpResponse.BodyHandlers.ofString())
+		if (wellKnownConfigurationResponse.statusCode() != 200) {
+			throw RuntimeException("Unable to fetch well-known configuration at $uri")
+		}
+		val wellKnownConfigurationRequestBodyString = wellKnownConfigurationResponse.body()
+		val wellKnownConfigurationRequestBodyJsonObject = JSON.readObject(wellKnownConfigurationRequestBodyString)
 
-	override fun authenticate(username: String, password: String): Authentication = throw UnsupportedOperationException("Cannot authenticate with MariaDB")
-
+		tokenEndpointUri = wellKnownConfigurationRequestBodyJsonObject.getString("token_endpoint")
+		jwksUri = wellKnownConfigurationRequestBodyJsonObject.getString("jwks_uri")
+		userinfoEndpointUri = wellKnownConfigurationRequestBodyJsonObject.getString("userinfo_endpoint")
+		grantTypesSupported = wellKnownConfigurationRequestBodyJsonObject.getArray("grant_types_supported").map { it.toString() }.toSet()
+	}
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -16,4 +16,6 @@ open module holocore {
 	requires fast.json;
 	requires kotlin.stdlib;
 	requires kotlin.reflect;
+	requires java.net.http;
+	requires com.auth0.jwt;
 }

--- a/src/test/resources/swg-realm.json
+++ b/src/test/resources/swg-realm.json
@@ -1,0 +1,1946 @@
+{
+  "id" : "c43b36ad-2af9-4f56-a369-b6f8d4eff15a",
+  "realm" : "swg",
+  "displayName" : "Star Wars Galaxies",
+  "displayNameHtml" : "",
+  "notBefore" : 0,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 300,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : false,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : true,
+  "permanentLockout" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 3,
+  "roles" : {
+    "realm" : [ {
+      "id" : "e4f5b01e-e788-4ed8-8217-f528903606db",
+      "name" : "default-roles-swg",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
+        "client" : {
+          "account" : [ "view-profile", "manage-account" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "c43b36ad-2af9-4f56-a369-b6f8d4eff15a",
+      "attributes" : { }
+    }, {
+      "id" : "d5f85830-2acd-4436-b7e7-83675db9177f",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "c43b36ad-2af9-4f56-a369-b6f8d4eff15a",
+      "attributes" : { }
+    }, {
+      "id" : "6da84667-9006-4bb6-9a75-781e367dc6d1",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "c43b36ad-2af9-4f56-a369-b6f8d4eff15a",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "holocore-localhost" : [ {
+        "id" : "d13d06d3-2720-415b-8932-94ceb1d6d769",
+        "name" : "CSR",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+        "attributes" : { }
+      }, {
+        "id" : "4cbd46d1-3be1-4b69-b2df-53adac5b0f82",
+        "name" : "DEV",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+        "attributes" : { }
+      }, {
+        "id" : "dcef8e6c-fa2e-41f3-adab-113910d9f623",
+        "name" : "WARDEN",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+        "attributes" : { }
+      }, {
+        "id" : "2761ce21-d61a-4a47-9c11-c4da72571d73",
+        "name" : "QA",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+        "attributes" : { }
+      }, {
+        "id" : "32c25515-96aa-4d3c-8174-737f24aec7bc",
+        "name" : "LEAD_QA",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+        "attributes" : { }
+      }, {
+        "id" : "4dc4d8a2-1e3b-443f-8a43-afa2cac6e926",
+        "name" : "PLAYER",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+        "attributes" : { }
+      }, {
+        "id" : "8ea654c4-4633-4592-a66d-70b3931c73e9",
+        "name" : "LEAD_CSR",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+        "attributes" : { }
+      } ],
+      "realm-management" : [ {
+        "id" : "5e724dc7-6068-493c-a30f-956dcb42203a",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "a0c7b888-f536-413a-a024-f0a915ff415f",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "f8d30bc9-753b-412d-b8f2-b38a6b12124d",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "26ed4700-c3e2-4c4c-ad90-d4af68d1c99f",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "94c75ce8-9590-46fd-8665-9de3d8f585ef",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "manage-users", "manage-identity-providers", "query-clients", "manage-authorization", "manage-realm", "view-authorization", "manage-clients", "query-realms", "query-users", "manage-events", "view-realm", "create-client", "view-identity-providers", "view-clients", "view-events", "impersonation", "view-users", "query-groups" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "5810c2d6-973c-4ea8-9eab-485c52a8fc85",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "9dc94cd7-6692-4aaf-a3f3-8a3faabed5e8",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "b9cebc05-9299-4d42-bacb-d5a57c821a3e",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "d107aa45-8b93-447d-af91-604ae2c4251b",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "6e28ffaa-7704-4ab3-a861-c037a43e9f5d",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "1c4046f6-740b-40f8-8e6d-4074662c0fc4",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "24eeb4a8-2a41-4acd-8ed4-37e382e7aaba",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "248e75a0-11c1-431b-9461-8b08655d524e",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "c9b586f1-0c7c-4be2-9232-58347d0e0069",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "61ace48b-2cec-4578-b1e0-fa009f8683ac",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "26e1a829-5ed5-4fec-853a-dc492aac4cb5",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "8803c1f5-1fce-405f-a906-af1a9977d743",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "2dbcc387-93ba-4322-9090-89f0b4ead057",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-groups", "query-users" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      }, {
+        "id" : "43582d17-16b3-41b6-90d2-06db182034dc",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+        "attributes" : { }
+      } ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "088c8a3d-7d75-4e81-9592-7b13c969ddfe",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "30449f8b-4992-4a88-8ff9-7936a12bd4a2",
+        "attributes" : { }
+      } ],
+      "account" : [ {
+        "id" : "88c7220d-435f-4954-bfa2-deaf0d94d5a0",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      }, {
+        "id" : "ba885667-47ba-4b41-bb5c-c56a8c058fe8",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      }, {
+        "id" : "4665ffab-4fe9-4132-8584-5654f6dd1da2",
+        "name" : "view-groups",
+        "description" : "${role_view-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      }, {
+        "id" : "7c5bc6b7-3982-48fc-9727-a31b8cd70485",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      }, {
+        "id" : "1a9181b0-7f07-477f-88b2-ecd544bd4307",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      }, {
+        "id" : "9030c821-19c4-4d84-99a3-11bc7071e8c7",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      }, {
+        "id" : "6805e67e-380c-4b72-b05a-2de26f2bbadd",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      }, {
+        "id" : "382ef260-fe6c-47cf-8ddd-098478f8ab94",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ {
+    "id" : "3bf397c2-8fa5-441a-8090-dd4c9f0c96c2",
+    "name" : "admins",
+    "path" : "/admins",
+    "attributes" : { },
+    "realmRoles" : [ ],
+    "clientRoles" : {
+      "holocore-localhost" : [ "DEV" ]
+    },
+    "subGroups" : [ ]
+  }, {
+    "id" : "54f68ac8-fd28-495e-a647-67d5a825e027",
+    "name" : "players",
+    "path" : "/players",
+    "attributes" : { },
+    "realmRoles" : [ ],
+    "clientRoles" : {
+      "holocore-localhost" : [ "PLAYER" ]
+    },
+    "subGroups" : [ ]
+  } ],
+  "defaultRole" : {
+    "id" : "e4f5b01e-e788-4ed8-8217-f528903606db",
+    "name" : "default-roles-swg",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "c43b36ad-2af9-4f56-a369-b6f8d4eff15a"
+  },
+  "defaultGroups" : [ "/players" ],
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpPolicyCodeReusable" : false,
+  "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppMicrosoftAuthenticatorName", "totpAppGoogleName" ],
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "users" : [ {
+    "id" : "bafeb644-9282-42a6-aef1-a0046b3e462e",
+    "createdTimestamp" : 1695489511694,
+    "username" : "banned-user",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "firstName" : "",
+    "lastName" : "",
+    "attributes" : {
+      "banned" : [ "true" ]
+    },
+    "credentials" : [ {
+      "id" : "acc3c715-d247-4110-a25a-69f7bcdaec31",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1695539455116,
+      "secretData" : "{\"value\":\"Tqr5HP9OSdzJDnz3R9Hfd9ChPxZ2SV89ZoL3YNB9JnY=\",\"salt\":\"tlV9I73eZMtBIggeRuIq9w==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-swg" ],
+    "notBefore" : 0,
+    "groups" : [ "/players" ]
+  }, {
+    "id" : "5a9e50a3-64b5-4650-a36d-c902fefa904a",
+    "createdTimestamp" : 1695477065617,
+    "username" : "user",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "firstName" : "",
+    "lastName" : "",
+    "attributes" : {
+      "banned" : [ "false" ]
+    },
+    "credentials" : [ {
+      "id" : "069c93a4-889b-4e5e-97a5-99239e4d8925",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1695477084200,
+      "secretData" : "{\"value\":\"o58/EBHmYZ6XW0Xk5NjkxWwiSLOWwjSC/VTew/HogGE=\",\"salt\":\"rboqEuRe8PnQaEv6sw1I2g==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-swg" ],
+    "notBefore" : 0,
+    "groups" : [ "/admins" ]
+  } ],
+  "clients" : [ {
+    "id" : "b00cb4f5-95cd-40ad-ad53-b7cf23bd290f",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/swg/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/swg/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "3a1ac9dd-9271-46e4-8133-5b3d25145af3",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/swg/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/swg/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "3a09ba3c-f018-4329-90c4-d73cb046eaf0",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "b2aa2a50-0399-41f1-af95-41635aa88d51",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "30449f8b-4992-4a88-8ff9-7936a12bd4a2",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "b0b20fbe-1f65-4dbb-9ba1-a1940f6deae0",
+    "clientId" : "holocore-localhost",
+    "name" : "",
+    "description" : "",
+    "rootUrl" : "",
+    "adminUrl" : "",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "nrrtW0NqbNWXn62ii6218QHWbEhVGXaf",
+    "redirectUris" : [ "/*" ],
+    "webOrigins" : [ "/*" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "oidc.ciba.grant.enabled" : "false",
+      "client.secret.creation.time" : "1695477159",
+      "backchannel.logout.session.required" : "true",
+      "post.logout.redirect.uris" : "+",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "display.on.consent.screen" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "5fe816ae-53a3-44a1-873b-4bfb7834a81d",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "false",
+        "access.token.claim" : "false",
+        "claim.name" : "roles",
+        "jsonType.label" : "String",
+        "usermodel.clientRoleMapping.clientId" : "holocore-localhost"
+      }
+    }, {
+      "id" : "042e751d-e8f5-4072-96ba-f87163e64d91",
+      "name" : "Banned",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "aggregate.attrs" : "false",
+        "userinfo.token.claim" : "true",
+        "multivalued" : "false",
+        "user.attribute" : "banned",
+        "id.token.claim" : "false",
+        "access.token.claim" : "false",
+        "claim.name" : "banned",
+        "jsonType.label" : "boolean"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "5883477b-739e-4114-ba89-0bdb62ee23ed",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "d9324edd-9e39-4b66-89dd-b15a8f2734aa",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/swg/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/swg/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "0804a758-0b50-4641-98e4-c777b78cd070",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "432948a3-e509-44fd-a9fc-9f41d3ccc9d3",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "25b17b22-a52b-4376-ab04-f138e1e0bd57",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "4032a79b-409e-4575-8fa6-3b14c2bf049d",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${rolesScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "66d5488d-bb85-4ce4-bb26-204fb13f6d1c",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    }, {
+      "id" : "88fb06a7-8099-43d2-95a9-70c10cb3ff5a",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "168df763-c619-413c-8d00-8b8e00625e9c",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "userinfo.token.claim" : "false",
+        "user.attribute" : "foo",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true",
+        "claim.name" : "roles",
+        "jsonType.label" : "String",
+        "usermodel.clientRoleMapping.clientId" : "holocore"
+      }
+    } ]
+  }, {
+    "id" : "6c91c5ca-4aab-4138-9030-61dcab5fb5aa",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "42bdbb02-2a6f-44bc-8834-01566e002bfb",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d15aa7e4-b7a9-4652-994b-56f0610f1f3f",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "632998cf-e77f-4512-a082-e01d8e87f3dd",
+    "name" : "acr",
+    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "864bd5fa-8dfb-4e54-a3ae-f8c33c65e530",
+      "name" : "acr loa level",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-acr-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "0aa6f94c-97ea-4cd9-874f-50cab2b5c416",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "e33a30d2-a329-4bcb-98b3-eb567e8db9a4",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "ff151617-a0e4-43a1-8195-5d4649bddf35",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "5035352a-8538-4b22-ab75-d17bfe79bc07",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "16dfca22-1c08-4d6e-b59d-1960f3107e91",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "ccda6aeb-2acf-4ce1-8f10-be641d6bcc8e",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "857e1f90-bfc2-456d-b734-f6343e251a3b",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "371f3ffb-45b6-44f0-beda-31908098b7ca",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "faa66018-e1e9-4a80-8196-21315532695c",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "f073e1ae-d415-43e3-abdf-348fce616e05",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8a951015-2552-4df9-81c5-ad8f5a12f2d6",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "id" : "aeefd618-add1-4b40-b958-729dda3c18bf",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "3734ebb3-e91c-434b-a4c4-b2b9bf4497da",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "9bc62d20-1b07-4c77-bfc7-da6bc2550dec",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "79990067-cebe-462c-bef1-318e81b52660",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5b1b5cbc-0b15-4a08-a22b-21a3d3ef9258",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8c1bfdac-d4f9-4d0a-98ff-2258052f5f77",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "long"
+      }
+    }, {
+      "id" : "379465ac-4c89-45da-b67a-8b33f4aabc52",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5b6f2c7f-a026-4b2c-aee2-a4d0397525d5",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "732c20fc-98fc-41b1-a7dc-579796b94ea3",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "cb9c05de-2c4b-4a90-8962-8b2314f2d74f",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "fa049728-780a-411d-ab56-0b5cff044feb",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "3299c4f5-cc07-4b69-bfc9-0ca04d470a7b",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "cd632e98-9df9-41a1-b277-c5f978e0ac8f",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "681af47a-b940-405d-bf87-c5bcf6fd2cd4",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c012190f-fa76-4f77-bead-8337361a2a11",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "role_list", "profile", "email", "roles", "web-origins", "acr" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "referrerPolicy" : "no-referrer",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection" : "1; mode=block",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ ],
+  "identityProviderMappers" : [ ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "bd3d1c48-489f-48f7-b619-f452221011f2",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "saml-user-attribute-mapper", "oidc-address-mapper", "oidc-full-name-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-attribute-mapper", "oidc-usermodel-property-mapper" ]
+      }
+    }, {
+      "id" : "942a2c06-8868-4c00-ab59-1f547aa02e88",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "4533002e-e644-4e08-bf8d-fc4635256734",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "3cb6ddf7-e30f-4a5e-b047-0b3fa532efe6",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "00d073aa-56c3-46db-b06a-58a1fc29c770",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "51a7ed62-af76-4b6b-b4d2-2631e1771057",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "1f5d1d91-1113-4286-9c1c-687ff562eee1",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "3ecd403c-d88c-42b2-90f0-3b0f6e6c69c3",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-role-list-mapper", "oidc-usermodel-attribute-mapper", "oidc-address-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "saml-user-property-mapper", "saml-user-attribute-mapper" ]
+      }
+    } ],
+    "org.keycloak.userprofile.UserProfileProvider" : [ {
+      "id" : "8c0ff21b-8051-434f-80a4-9b3ded74e7d1",
+      "providerId" : "declarative-user-profile",
+      "subComponents" : { },
+      "config" : { }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "d46e0fa7-88aa-4e5d-ae9d-8cf57d3d4b61",
+      "name" : "hmac-generated",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "668c0087-a0e3-497a-8b9f-499907997a15" ],
+        "secret" : [ "fuFl_RGKY5Jnriwn2S5eJ7umDVzv6TjUJDAt0eO-0GcZ1BuDkC4J9NzvzXgB2ws3vGfxiHTj23Ug1N38tpY3wg" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS256" ]
+      }
+    }, {
+      "id" : "b28ef11e-2efe-4b02-b65f-e532dec0f6b7",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "7eb8d5fd-2292-4a83-800d-11672e53351c" ],
+        "secret" : [ "P1YtHoFCQmy5CjjpiFZ1Kw" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "28e2957e-1f5a-4378-a552-56d051dcac3a",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEAvL9x8kL2EIXWRKyE4ESlf6yL5T9PEhvd9zSdsUedyMeEbX1empJBpVFyxPy4IW/e+w0J/JWh/FWilwqQrQFviyzQCe5w47Xtx9woDNpeEFfUtPEbYVeeOtiO/JHpel4lEgcB1juKk30Xcaf0Ev107A4uDGb+TQqt+b2afK/pKcO8S8JBOBo4HHy+qPiAkyAaBqpXPYEEnt5t3fv6N7SNzEEm9UWuP1beLHEcRblYYDonc5J2ElZao5sQ/mdytz+hrGi1JF7f4wzZ0Yf9Jf9LZKVofcqCJ20TZ6Nwnn3QX1zcNZvmr8ltSgQfm1tvk7wEsi/50oa8Fw31Mqr/2Xw9GwIDAQABAoIBABACE1xJrkGZKE1rbbBGV4cBj7KMxlxcfVyMW4d/8cjn6w+3igDawLM7D4cs1pe3ZkECn8M1aadTbVZuxfXLtmB7wiqQIjDzQCHVm+v4epvbkdBwK937UWc08MOebcqRa4bLjgNTyh1XhwJ+YnwDKm8kMLxKi+zlfVCTcnklbkVlYs00aGsK5k1y8Kc8IQddW+woWp+UdQi7jwo01MRYyY0SjBx3IAORqUTch7nR33KMpfhFE+HgDpjxHavVg0U4QGSzx4jcwUMWYCwhgcBId+Yn5116UgEFx/2jHLtzIfywKgNMRnnDMWYhcT6hQTs1m2X3zQmytlJmQaQmueffyTECgYEA5hiWKdFCEseTIsoykwP4VkrKV3quliaCUGpZd2VStUYwXlcKLHi5mSXDY3gren0tK/G6byVbrMRI2eIiP2SLFEbQHu6TgnGD1b+HLqxVChS6CvFSUTU4MVVbS4RomVsgIzXkMn/Zg3wqgWgXklYdH6o19Tr+HC7qsURjqvhPiNkCgYEA0f8x6XZR90oT9hKJLpmAEsJbNihII+UqRsp9JQqnVcot5ghWOoZByuetGJnGHuZgtJk9FZrND57ioxXr3EmncaRZL6R0ueMZAjxEfCpv3KIzmtU9F+AV2v11lg3C3DstG5XpVT8qpNOZYcUqelXDEUPy8LP6StWcj+vd46DonRMCgYEAxu7Y3RyraHsdzcVNBmg3S7vrxsgtq2lt30KjSSPT5x/g75+HDz3tEOhiTlx2Ereo10Zt7mw5H1yws5fcDjzKNeSnSSbxZ6Tm22V05bhe6ZFT6+QKTGWbyKNIhDjdCkGLvoV4XuTEVPaD9U/emUlUcq0Ba5zuV8WEaXB8TzPR57kCgYAO3iKKhPYIrBX9thJAWl3W9iu/CdsRr4fuuydhGAAA8u+M+cohGqBN3VlEBJ8iUO1H3BGXFf6uvHEPWt34Gr7gLOKjnOEmyA1dOyceI2MIG/PLYo2QwyzI9Gj+1rqVHRt0eIisoGxEfza81VjMkIXfExCAOj3eToFnLyvmkd3mQQKBgF7ksGo4JR3+JAEKj7lnwkPZqI+SRBOSUE1x/N1fk/aNBomg8SCqJFNekmJWGzXlNC2nC/6ysbiaijTa2Al9/EtCTgI1iAhlQ89DvUyk3TkTaxG2hsUC8Y5nB8OQf7Il+pRk547NLCqXquxi8saGlVeh3Sjzo7DyOMrUshx42b12" ],
+        "keyUse" : [ "ENC" ],
+        "certificate" : [ "MIIClTCCAX0CBgGKwk5aMzANBgkqhkiG9w0BAQsFADAOMQwwCgYDVQQDDANzd2cwHhcNMjMwOTIzMTM0ODQ5WhcNMzMwOTIzMTM1MDI5WjAOMQwwCgYDVQQDDANzd2cwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8v3HyQvYQhdZErITgRKV/rIvlP08SG933NJ2xR53Ix4RtfV6akkGlUXLE/Lghb977DQn8laH8VaKXCpCtAW+LLNAJ7nDjte3H3CgM2l4QV9S08RthV5462I78kel6XiUSBwHWO4qTfRdxp/QS/XTsDi4MZv5NCq35vZp8r+kpw7xLwkE4GjgcfL6o+ICTIBoGqlc9gQSe3m3d+/o3tI3MQSb1Ra4/Vt4scRxFuVhgOidzknYSVlqjmxD+Z3K3P6GsaLUkXt/jDNnRh/0l/0tkpWh9yoInbRNno3CefdBfXNw1m+avyW1KBB+bW2+TvASyL/nShrwXDfUyqv/ZfD0bAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAKtXXejDnu+0QN3H8/kgKk/CgXa8guPa8NDjPo4ngC+L+ADD7kP7yE42gFxrv0nMBSKrAnHwAvdhAY2BpROToSjoca6sTjBohjSm0caGW3RK5iZLc3Yb1DHw++Du5UfjnBsrtdSW7N7RfEn6WfdGytRRGAOES3rmjmQ62yZ7/XpDAX3XFIn59QqBl9Fe7JCshLm3irbw0D595vnGp74LydT27/G6QUQ7H9A3D8frbi/619Q7VRxZBGNP3RdEfGje/UqqMIqxAsJQBrSUurEpn25WBhlg1xPQ7b0i6OQUUqURqoE0OPZ0sfBZ7QxNoHt9yPGbM4MLypCEAz9/r2Id2Yw=" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
+      }
+    }, {
+      "id" : "8a999290-b6e8-48b7-9876-c592f013fcac",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEpAIBAAKCAQEAv5Y04QpyrYgcivikT9wjSyk8olhtq7J82GEZ6ijYiUWBq+YahBpgwf7YRSlE+9EXWykpUGnrJJJRuxMc/HgGc1pC/WR9GjB38QE0Her4ZFndrWj7W5ZC40FmwAAgvK5jtzkhEmJDC9OBWKeDgDUwF2nI79+YavB8rFHCIxUrJMAKfZy4WzG29sLWo0oGDPF9k0SdX2qgvWx3OKv4+UK91UctB15W7MSEH88U4xEAucvVGll46sF9FdAxRysENGETXy2APACoOHmy2i0cs3xh9AVm7rUlLwe5yTTw+/NvYU3mugcoObarr/DSZoPoENEQ3RtnFaQDLd0E/S2RR+DbzwIDAQABAoIBABZNWPh9a94RgykWSqJVQPKF6V4IpzOegnP50bd1a8eHBNJK5flMzMiobuqWJEagD3T4NKv8uHe4ZLU/Q1eMbUvOTRAMO5fp3nx6pGN7L9EWuPxvxRrjQgQMX/anzSfJsSfqCZSHRcDBrUPxtBgfmOqQ0OhDgg2o0wqINe45j50mXkBdAnu75ftmxRm555oKuMtc10pOuz2ywSYGuY9nnSBe5X9AIdp9iqzcabIaNH6jtvUCYeo4HDksKtx+aJq2zftoW7n8QsT5nTvvqiEv/uVldr1R3JXAkV1keY8TkJeEDacwbWOkeLTcHDUw3/yBdAGAp9sqwZ6Ha1SqgqlmeokCgYEA4aWvdXy8ftd0fEwNsbKbZ+7tHjl133NJ5BMwhKRffY7KIrxnGsB4sEEaeRGEPydl2SeEjMM8WTyB3vRuSc5AjA9FJDF0l5NPDEBPigCB3Yjt/t3W/IfoheX8Xaxgec3jivVVNxZbxSLiaM4wTK+npGn83UJw6iAf2TxoFPu1JnUCgYEA2VugQURSVJFfLmYrAOaF6FaauKiW6eDNahS98Wy07P1NOiOVUI3l2EktH61P/9t6B97JjKq5ThYp6Xi2t+DLcLjCXpR2oX/OQ32/tLJNohGeXWb8fyxvdxGAFdNpfreZ1bQMbGvOuYqDHlocVYC5MdQbo/igsxEgd+Obqd6sGLMCgYEA3MEvqw1hi+ZVe9UcAKDwEPpa2Jr2iqlLvOpZKSt2kGvFrb4MUMvERwsqTw+oBfERXyWeM+g9fkAH/ou76lDyLRQzXHlVy4S+bQntxuFAK+/uhs2Zqm18OqMKBsrBh+i5mBT0TXR+S5sZTdeKwTuIEv3t+LkrpqHPBsRmP0ERtJECgYB62H5KZQLjKQZSgwvrBl7IYaowk5g3twZh3jc8K+RVzRPIuDO7w3cUNsd6D8oXIURnDlN7XUI+D+jAO6mJY1OX8dRpAB/MRx+cpYWj6uJVpv+KappqhgK5mPp7W3FUXRBk583duVCtLMvOa79307jXoLm+gtbQXe2r1Mg1ydQaYQKBgQCoz9uJzmOhYikHvntZ6tHG9meVJsLTuoDsOnaGc2XnETl/q1lCiA8u5mcMiFAtwBqZhtXHY5EALpoHlopvXlcP0TQJ34XRyJIBp6NNrdMgQmu+nHR/J/4MVB+4LS97QFITPFJWYK2tU6gJhoy5e7njsSygGM/gR8HquxlkdYSAVw==" ],
+        "keyUse" : [ "SIG" ],
+        "certificate" : [ "MIIClTCCAX0CBgGKwk5ZuzANBgkqhkiG9w0BAQsFADAOMQwwCgYDVQQDDANzd2cwHhcNMjMwOTIzMTM0ODQ5WhcNMzMwOTIzMTM1MDI5WjAOMQwwCgYDVQQDDANzd2cwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/ljThCnKtiByK+KRP3CNLKTyiWG2rsnzYYRnqKNiJRYGr5hqEGmDB/thFKUT70RdbKSlQaeskklG7Exz8eAZzWkL9ZH0aMHfxATQd6vhkWd2taPtblkLjQWbAACC8rmO3OSESYkML04FYp4OANTAXacjv35hq8HysUcIjFSskwAp9nLhbMbb2wtajSgYM8X2TRJ1faqC9bHc4q/j5Qr3VRy0HXlbsxIQfzxTjEQC5y9UaWXjqwX0V0DFHKwQ0YRNfLYA8AKg4ebLaLRyzfGH0BWbutSUvB7nJNPD7829hTea6Byg5tquv8NJmg+gQ0RDdG2cVpAMt3QT9LZFH4NvPAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJ24o5H6Iqk+9MU6MmGP53eMOj4NOgbY5MkWtLYvEWBFqZ8IznwYr4YD0yp33toIjX30abGVs4s6AWTvmGf0FLWXLcW1WNUdlkf0uE2bqpsQXodApQWDqEExBq87Ly/qbpOdRS/JJr7zWwqSzPqEIkbj/7rQnCCv9mPMiZ5M+AtSQg2UH7bpkVejxEabzv9Cgehdqi/3xisvKYS1ZokkFcsGS/Rr98utCjBZBO7bZEwWwBhu848tRqL1ZoLXCoBY6qIaufVB/O4PjpzH5uAj8BnZBpENtOImCK39K4ebsd8+QuYGoFJ1RynG8SODx8+IOtJj0epQ2/+FzjW4NCMRZUo=" ],
+        "priority" : [ "100" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "id" : "608fcd5a-d937-4b5a-ab20-0e5e42d57de3",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "a152f0ef-7efe-4804-a3fa-127b05869b47",
+    "alias" : "Browser - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "d464b263-3e5d-4b4a-ae99-cf23944ce176",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "209bc4f0-49ea-4b5a-a1fe-e665aae0d6ad",
+    "alias" : "First broker login - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "3b6ee3a5-f71c-41d8-94f3-107115d53bf4",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "c4381ac0-3d57-4a45-b2b8-84fbfd2398f5",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "30456245-b0fd-431c-b7e0-afeb1a7638a9",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "e7d598cd-2a6f-4a03-a0cf-6a3ce1b90f47",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First broker login - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "938ef660-b2f3-4862-be3a-f5b6901a01bb",
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "d2e49d48-d121-4e03-a0ee-d1d9762406ef",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "044599ba-aba1-4143-9035-4311953c4ae8",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "87827e43-b4d8-4739-a57c-4da4c7ea8e6c",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "296a770a-1161-4b6a-aca2-0b516881b123",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "e6873ac3-3c64-4e38-af68-22901522eae0",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "eedd4de0-8568-47ca-b346-3ae2823b06c3",
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "d8ab5055-32e9-4b9f-a1b2-1e3e63074add",
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-profile-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "6f05f526-5c56-4984-a034-6b775ed99c17",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "0681d017-10a4-4279-a2d1-2f52e9126d6f",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "f41ecfc7-8ed7-4b14-814d-9d355cae7193",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "c51be89c-45c4-4b9a-bc60-66efd12c5065",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "TERMS_AND_CONDITIONS",
+    "name" : "Terms and Conditions",
+    "providerId" : "TERMS_AND_CONDITIONS",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  }, {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register",
+    "name" : "Webauthn Register",
+    "providerId" : "webauthn-register",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 70,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register-passwordless",
+    "name" : "Webauthn Register Passwordless",
+    "providerId" : "webauthn-register-passwordless",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 80,
+    "config" : { }
+  }, {
+    "alias" : "update_user_locale",
+    "name" : "Update User Locale",
+    "providerId" : "update_user_locale",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 1000,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "clientOfflineSessionMaxLifespan" : "0",
+    "oauth2DevicePollingInterval" : "5",
+    "clientSessionIdleTimeout" : "0",
+    "clientOfflineSessionIdleTimeout" : "0",
+    "cibaInterval" : "5",
+    "realmReusableOtpCode" : "false",
+    "cibaExpiresIn" : "120",
+    "oauth2DeviceCodeLifespan" : "600",
+    "parRequestUriLifespan" : "60",
+    "clientSessionMaxLifespan" : "0",
+    "frontendUrl" : "",
+    "acr.loa.map" : "{}"
+  },
+  "keycloakVersion" : "22.0.3",
+  "userManagedAccessAllowed" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
+  },
+  "clientPolicies" : {
+    "policies" : [ ]
+  }
+}


### PR DESCRIPTION
# Why?
Providing server hosters with an alternative way to manage users, requiring no custom code or direct MongoDB access.

Holocore still doesn't know anything about user management - this remains the concern of external tooling.

# Existing deployments
MongoDB user authentication still works and remains the default for Docker deployments.

MongoDB user authentication tests still pass.

# Local development
OIDC auth is now the default for empty MongoDB servers. For that reason, no change in behavior will be seen if you already have a bootstrapped MongoDB server.

There's still a default game user for local development with the same credentials as the old one.

# PswgUserDatabase
I had to change the `PswgUserDatabase` API a bit, as it wasn't very compatible with OAuth 2.0. Specifically, you can only look up user details _after_ the user has authenticated, which Holocore did in reverse order. Holocore looked up user details, _then_ authenticated the user afterwards.
The two methods have been merged into one.

There's a MariaDB implementation of the interface we could _probably_ delete, but this PR was pretty big already, so I decided against it for now :smile: 