### PR TITLE
Compound run configuration for starting docker-compose and then holocore

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+holocore

--- a/.idea/runConfigurations/Start.xml
+++ b/.idea/runConfigurations/Start.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Start" type="CompoundRunConfigurationType">
+    <toRun name="docker-compose.yml: Compose Deployment" type="docker-deploy" />
+    <toRun name="Start server (development)" type="GradleRunConfiguration" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,9 @@ This will also run a web UI, which can be accessed in the browser at: http://loc
 You can stop both with: `docker-compose down`.
 
 ### Running Holocore
-In IntelliJ idea, run the **Start server (development)** run configuration.
+In IntelliJ idea, run the **Start** run configuration.
 
-**NOTE**: A MongoDB instance must be running for the server to start.
+**NOTE**: Docker must be running in the background for MongoDB to start properly.
 
 ### Running automated tests
 In IntelliJ idea, run the **Tests** run configuration.


### PR DESCRIPTION
The idea being that you just click "Start" and everything works. Obviously you still need to consider Docker, but you also needed to do that before 😄 

The settings for the run configuration look like this:
![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/aab00ada-08e7-45dc-a770-f36c1ac11a67)
