### PR TITLE
Store generated mount inside Pet Control Device

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/objects/swg/SWGObject.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/swg/SWGObject.java
@@ -866,6 +866,10 @@ public abstract class SWGObject extends BaselineObject implements Comparable<SWG
 	public void setServerAttribute(ServerAttribute key, Object value) {
 		serverAttributes.put(key, value);
 	}
+
+	public void removeServerAttribute(ServerAttribute key) {
+		serverAttributes.remove(key);
+	}
 	
 	public Object getDataAttribute(ObjectDataAttribute key) {
 		return dataAttributes.get(key);

--- a/src/main/java/com/projectswg/holocore/services/gameplay/world/travel/PlayerMountService.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/world/travel/PlayerMountService.java
@@ -231,10 +231,10 @@ public class PlayerMountService extends Service {
 	@NotNull
 	private static IntangibleObject createVehicleControlDevice(CreatureObject creator, String pcdTemplate, VehicleInfo vehicleInfo) {
 		IntangibleObject vehicleControlDevice = (IntangibleObject) ObjectCreator.createObjectFromTemplate(pcdTemplate);
-		ObjectCreatedIntent.broadcast(vehicleControlDevice);
 		CreatureObject mount = createMountObject(creator, vehicleInfo.getObjectTemplate());
 		mount.systemMove(vehicleControlDevice);
 		vehicleControlDevice.setCount(IntangibleObject.COUNT_PCD_STORED);
+		ObjectCreatedIntent.broadcast(vehicleControlDevice);
 		return vehicleControlDevice;
 	}
 

--- a/src/main/java/com/projectswg/holocore/services/gameplay/world/travel/PlayerMountService.java
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/world/travel/PlayerMountService.java
@@ -407,7 +407,7 @@ public class PlayerMountService extends Service {
 			
 			// Put away the mount
 			mountControlDevice.setCount(IntangibleObject.COUNT_PCD_STORED);
-			mount.systemMove(mountControlDevice);
+			mount.moveToContainer(mountControlDevice);
 			StandardLog.onPlayerTrace(this, player, "stored mount %s at %s %s", mount, mount.getTerrain(), mount.getLocation().getPosition());
 		}
 		cleanupCalledMounts();


### PR DESCRIPTION
Relates to #1336.

Basically: The game won't be able to display the color customization of the vehicle in the datapad (#1293), unless we store the customized `CreatureObject` inside the PCD. **Ideally nothing changes from the perspective of the player.**