### PR TITLE
Fixed client crash when being granted a quest #1383

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/objects/swg/player/PlayerObject.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/swg/player/PlayerObject.kt
@@ -199,7 +199,6 @@ class PlayerObject(objectId: Long) : IntangibleObject(objectId, BaselineType.PLA
 
 	val completedQuests by play8::completedQuests
 	val activeQuests by play8::activeQuests
-	var activeQuest by play8::activeQuest
 
 	val quests: Map<CRC, Quest>
 		get() = play8.getQuests()

--- a/src/main/java/com/projectswg/holocore/resources/support/objects/swg/player/Quest.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/swg/player/Quest.kt
@@ -47,14 +47,14 @@ class Quest : Encodable, MongoPersistable {
 		}
 	var isRewardReceived = false
 	var counter = 0
+	var ownerId: Long = 0
 
 	override fun decode(data: NetBuffer) {
-		data.long
+		ownerId = data.long
 		val newActiveTasks = BitSet.valueOf(data.getArray(java.lang.Short.BYTES))
 		val newCompletedTasks = BitSet.valueOf(data.getArray(java.lang.Short.BYTES))
 		isComplete = data.boolean
 		counter = data.int
-		isRewardReceived = data.boolean
 
 		// Must be set at the end to avoid being overwritten on the setter for `isComplete`
 		activeTasks.clear()
@@ -65,16 +65,15 @@ class Quest : Encodable, MongoPersistable {
 
 	override fun encode(): ByteArray {
 		val buffer = NetBuffer.allocate(length)
-		buffer.addLong(0) // ID for quest giver?
+		buffer.addLong(ownerId)
 		buffer.addRawArray(Arrays.copyOf(activeTasks.toByteArray(), java.lang.Short.BYTES))
 		buffer.addRawArray(Arrays.copyOf(completedTasks.toByteArray(), java.lang.Short.BYTES))
 		buffer.addBoolean(isComplete)
 		buffer.addInt(counter)
-		buffer.addBoolean(isRewardReceived)
 		return buffer.array()
 	}
 
-	override val length: Int = 18
+	override val length: Int = 17
 
 	override fun readMongo(data: MongoData) {
 		activeTasks = BitSet.valueOf(data.getByteArray("activeSteps"))

--- a/src/test/java/com/projectswg/holocore/resources/gameplay/conversation/requirements/QuestSerializationTest.kt
+++ b/src/test/java/com/projectswg/holocore/resources/gameplay/conversation/requirements/QuestSerializationTest.kt
@@ -37,17 +37,17 @@ class QuestSerializationTest {
 	@Test
 	fun `test quest encode decode`() {
 		val q = Quest()
+		q.ownerId = 1234
 		q.addActiveTask(1)
 		q.addCompletedTask(2)
 		q.counter = 15
-		q.isRewardReceived = true
 
 		val decoded = Quest()
 		decoded.decode(NetBuffer.wrap(q.encode()))
 
+		assertEquals(1234, decoded.ownerId)
 		assertTrue(decoded.getActiveTasks().contains(1))
 		assertEquals(15, decoded.counter)
-		assertEquals(true, decoded.isRewardReceived)
 		assertArrayEquals(q.encode(), decoded.encode())
 	}
 


### PR DESCRIPTION
Fixes #1383. Tested.

There were two issues:
1. The Quest struct had an extra variable that's not used pre-NGE
2. Pre-NGE doesn't have an `activeQuest` variable, and having it caused a delta offset with the `quests` map