### PR TITLE
Quest SUI message boxes

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/QuestLoader.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/QuestLoader.java
@@ -60,14 +60,23 @@ public class QuestLoader extends DataLoader {
 				Set<String> columns = new LinkedHashSet<>(set.getColumns());
 				String type = set.getText("attach_script");
 				String name = set.getText("task_name");
-				String commMessageText = set.getText("comm_message_text");
-				String npcAppearanceServerTemplate = set.getText("npc_appearance_server_template");
+				String commMessageText = null;
+				if (columns.contains("comm_message_text")) {
+					commMessageText = set.getText("comm_message_text");
+				}
+				String npcAppearanceServerTemplate = null;
+				if (columns.contains("npc_appearance_server_template")) {
+					npcAppearanceServerTemplate = set.getText("npc_appearance_server_template");
+				}
 				String targetServerTemplate = null;
 				if (columns.contains("target_server_template")) {
 					targetServerTemplate = set.getText("target_server_template");
 				}
 				String grantQuestOnComplete = set.getText("grant_quest_on_complete");
-				int count = (int) set.getInt("count");
+				int count = 0;
+				if (columns.contains("count")) {
+					count = (int) set.getInt("count");
+				}
 				int minTime = 0;
 				if (columns.contains("min_time")) {
 					minTime = (int) set.getInt("min_time");
@@ -77,6 +86,14 @@ public class QuestLoader extends DataLoader {
 					maxTime = (int) set.getInt("max_time");
 				}
 				String[] nextTasksOnComplete = set.getText("tasks_on_complete").split(",");
+				String messageBoxTitle = null;
+				if (columns.contains("message_box_title")) {
+					messageBoxTitle = set.getText("message_box_title");
+				}
+				String messageBoxText = null;
+				if (columns.contains("message_box_text")) {
+					messageBoxText = set.getText("message_box_text");
+				}
 				
 				QuestTaskInfo questTaskInfo = new QuestTaskInfo();
 				
@@ -98,6 +115,8 @@ public class QuestLoader extends DataLoader {
 				questTaskInfo.setCount(count);
 				questTaskInfo.setMinTime(minTime);
 				questTaskInfo.setMaxTime(maxTime);
+				questTaskInfo.setMessageBoxTitle(messageBoxTitle);
+				questTaskInfo.setMessageBoxText(messageBoxText);
 				
 				questTaskInfos.add(questTaskInfo);
 			}
@@ -196,6 +215,8 @@ public class QuestLoader extends DataLoader {
 		private String grantQuestOnComplete;
 		private int minTime;
 		private int maxTime;
+		private String messageBoxTitle;
+		private String messageBoxText;
 		
 		private QuestTaskInfo() {
 			nextTasksOnComplete = new ArrayList<>();
@@ -204,7 +225,23 @@ public class QuestLoader extends DataLoader {
 		public int getMinTime() {
 			return minTime;
 		}
-		
+
+		public String getMessageBoxTitle() {
+			return messageBoxTitle;
+		}
+
+		public void setMessageBoxTitle(String messageBoxTitle) {
+			this.messageBoxTitle = messageBoxTitle;
+		}
+
+		public String getMessageBoxText() {
+			return messageBoxText;
+		}
+
+		public void setMessageBoxText(String messageBoxText) {
+			this.messageBoxText = messageBoxText;
+		}
+
 		private void setMinTime(int minTime) {
 			this.minTime = minTime;
 		}

--- a/src/main/java/com/projectswg/holocore/resources/support/global/commands/callbacks/admin/CmdActivateQuest.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/global/commands/callbacks/admin/CmdActivateQuest.kt
@@ -1,0 +1,46 @@
+/***********************************************************************************
+ * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.resources.support.global.commands.callbacks.admin
+
+import com.projectswg.holocore.intents.gameplay.player.quest.GrantQuestIntent
+import com.projectswg.holocore.intents.support.global.chat.SystemMessageIntent
+import com.projectswg.holocore.resources.support.global.commands.ICmdCallback
+import com.projectswg.holocore.resources.support.global.player.AccessLevel
+import com.projectswg.holocore.resources.support.global.player.Player
+import com.projectswg.holocore.resources.support.objects.swg.SWGObject
+
+class CmdActivateQuest : ICmdCallback {
+	override fun execute(player: Player, target: SWGObject?, args: String) {
+		if (player.accessLevel == AccessLevel.PLAYER) {
+			SystemMessageIntent.broadcastPersonal(player, "Players cannot use this command :(")
+			return
+		}
+		
+		GrantQuestIntent.broadcast(player, args)
+	}
+
+}

--- a/src/main/java/com/projectswg/holocore/services/support/global/commands/CommandExecutionService.java
+++ b/src/main/java/com/projectswg/holocore/services/support/global/commands/CommandExecutionService.java
@@ -164,6 +164,7 @@ public class CommandExecutionService extends Service {
 		registerScriptCallback("cmdInvulnerable", CmdInvulnerable::new);
 		registerScriptCallback("cmdGrantSkill", CmdGrantSkill::new);
 		registerScriptCallback("cmdSetFaction", CmdSetFaction::new);
+		registerScriptCallback("cmdActivateQuest", CmdActivateQuest::new);
 	}
 	
 	private void addChatScripts() {

--- a/src/test/java/com/projectswg/holocore/resources/support/data/server_info/loader/TestQuestLoader.java
+++ b/src/test/java/com/projectswg/holocore/resources/support/data/server_info/loader/TestQuestLoader.java
@@ -124,6 +124,18 @@ public class TestQuestLoader {
 		}
 		
 		@Test
+		public void canLoadMessageBoxTitle() {
+			List<QuestLoader.QuestTaskInfo> taskListInfos = ServerData.INSTANCE.getQuestLoader().getTaskListInfos("quest/c_newbie_start");
+			assertEquals("@quest/ground/c_newbie_start:task00_message_box_title", taskListInfos.get(0).getMessageBoxTitle());
+		}
+		
+		@Test
+		public void canLoadMessageBoxText() {
+			List<QuestLoader.QuestTaskInfo> taskListInfos = ServerData.INSTANCE.getQuestLoader().getTaskListInfos("quest/c_newbie_start");
+			assertEquals("@quest/ground/c_newbie_start:task00_message_box_text", taskListInfos.get(0).getMessageBoxText());
+		}
+		
+		@Test
 		public void canLoadNpcAppearanceServerTemplate() {
 			assertEquals("object/mobile/boba_fett.iff", taskListInfos.get(5).getNpcAppearanceServerTemplate());
 		}


### PR DESCRIPTION
Relates to #1400.

I tested the message box in-game with:
`/activateQuest quest/c_newbie_start`.

I also expanded the automated tests for QuestLoader. Turns out that a whole lot more columns needed to be optional.