### PR TITLE
Feature/quest/destroy multi

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/gameplay/world/weather/EnvironmentService.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/world/weather/EnvironmentService.kt
@@ -84,7 +84,7 @@ class EnvironmentService : Service() {
 	}
 
 	private fun updateTime() {
-		NotifyPlayersPacketIntent(ServerTimeMessage(ProjectSWG.getGalacticTime())).broadcast()
+		NotifyPlayersPacketIntent(ServerTimeMessage(ProjectSWG.galacticTime)).broadcast()
 	}
 
 	private fun maybeUpdateWeather(terrain: Terrain) {


### PR DESCRIPTION
Relates to #1387

In a nutshell:
* We weren't populating the quest journal with the kill counts at all. We do now.
* I ran into a bad packet implementation (`QuestTaskCounterMessage`) while fixing the above bullet point. This has been fixed as well.

This is a test quest (quest/test_destroy_multiple) bundled with SWG, so ignore the missing strings.
You must kill three womp rats.

![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/0106f44e-e3e1-48c9-9035-32d100450a06)
![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/3339b4a4-5dea-4ecb-a576-b9a2f3f5a758)
![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/8ddff47f-dbaf-4f33-95f1-2be4631ec6de)
