### PR TITLE
[Items] Fixed static item weapons being created without skillmods

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/objects/StaticItemCreator.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/StaticItemCreator.kt
@@ -138,6 +138,7 @@ object StaticItemCreator {
 		weapon.specialAttackCost = info.specialAttackCost
 		weapon.requiredSkill = info.requiredSkill
 
+		applySkillMods(obj, info.skillMods)
 		applyItemValue(info.value, obj)
 	}
 

--- a/src/test/java/com/projectswg/holocore/resources/support/objects/StaticItemCreatorTest.kt
+++ b/src/test/java/com/projectswg/holocore/resources/support/objects/StaticItemCreatorTest.kt
@@ -1,0 +1,42 @@
+/***********************************************************************************
+ * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.resources.support.objects
+
+import com.projectswg.holocore.resources.support.objects.swg.weapon.WeaponObject
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class StaticItemCreatorTest {
+	@Test
+	fun skillModsOnWeapons() {
+		val weapon = StaticItemCreator.createItem("weapon_tow_cannon_02_01") as WeaponObject
+
+		val skillMods = weapon.skillMods
+		
+		assertTrue(skillMods.isNotEmpty())
+	}
+}


### PR DESCRIPTION
During development of #1433, I noticed that the Lava Cannon I tested with was supposed to have some skillmods on it.

This fixes that problem.