### PR TITLE
Re-enable novice in all professions, so we can work on testing them

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/global/zone/creation/CharacterCreation.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/global/zone/creation/CharacterCreation.java
@@ -156,11 +156,11 @@ public class CharacterCreation {
 		// New characters are Novices in all basic professions in the Combat Upgrade
 		new GrantSkillIntent(GrantSkillIntent.IntentType.GRANT, "species_" + creatureObj.getRace().getSpecies(), creatureObj, true).broadcast();
 		new GrantSkillIntent(GrantSkillIntent.IntentType.GRANT, "social_entertainer_novice", creatureObj, true).broadcast();
-		// new GrantSkillIntent(GrantSkillIntent.IntentType.GRANT, "outdoors_scout_novice", creatureObj, true).broadcast();
-		// new GrantSkillIntent(GrantSkillIntent.IntentType.GRANT, "science_medic_novice", creatureObj, true).broadcast();
-		// new GrantSkillIntent(GrantSkillIntent.IntentType.GRANT, "crafting_artisan_novice", creatureObj, true).broadcast();
+		new GrantSkillIntent(GrantSkillIntent.IntentType.GRANT, "outdoors_scout_novice", creatureObj, true).broadcast();
+		new GrantSkillIntent(GrantSkillIntent.IntentType.GRANT, "science_medic_novice", creatureObj, true).broadcast();
+		new GrantSkillIntent(GrantSkillIntent.IntentType.GRANT, "crafting_artisan_novice", creatureObj, true).broadcast();
 		new GrantSkillIntent(GrantSkillIntent.IntentType.GRANT, "combat_brawler_novice", creatureObj, true).broadcast();
-		// new GrantSkillIntent(GrantSkillIntent.IntentType.GRANT, "combat_marksman_novice", creatureObj, true).broadcast();
+		new GrantSkillIntent(GrantSkillIntent.IntentType.GRANT, "combat_marksman_novice", creatureObj, true).broadcast();
 		
 		// Everyone can Burst Run
 		creatureObj.addCommand("burstrun");

--- a/src/test/java/com/projectswg/holocore/resources/support/global/zone/creation/CharacterCreationTest.kt
+++ b/src/test/java/com/projectswg/holocore/resources/support/global/zone/creation/CharacterCreationTest.kt
@@ -1,22 +1,76 @@
 package com.projectswg.holocore.resources.support.global.zone.creation
 
-import com.projectswg.common.network.packets.swg.login.creation.ClientCreateCharacter
-import com.projectswg.holocore.resources.support.data.server_info.loader.DataLoader
-import com.projectswg.holocore.resources.support.global.player.AccessLevel
+import com.projectswg.holocore.headless.HeadlessSWGClient
+import com.projectswg.holocore.headless.MemoryUserDatabase
 import com.projectswg.holocore.resources.support.objects.swg.SWGObject
 import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject
-import com.projectswg.holocore.test.resources.GenericPlayer
-import com.projectswg.holocore.test.runners.TestRunnerSynchronousIntents
+import com.projectswg.holocore.services.gameplay.combat.CombatDeathblowService
+import com.projectswg.holocore.services.gameplay.combat.CombatExperienceService
+import com.projectswg.holocore.services.gameplay.player.experience.ExperiencePointService
+import com.projectswg.holocore.services.gameplay.player.experience.skills.SkillService
+import com.projectswg.holocore.services.support.global.commands.CommandExecutionService
+import com.projectswg.holocore.services.support.global.commands.CommandQueueService
+import com.projectswg.holocore.services.support.global.zone.LoginService
+import com.projectswg.holocore.services.support.global.zone.ZoneService
+import com.projectswg.holocore.services.support.global.zone.creation.CharacterCreationService
+import com.projectswg.holocore.test.runners.TestRunnerSimulatedWorld
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class CharacterCreationTest : TestRunnerSynchronousIntents() {
+class CharacterCreationTest : TestRunnerSimulatedWorld() {
+
+	private val memoryUserDatabase = MemoryUserDatabase()
+
+	@BeforeEach
+	fun setUp() {
+		registerService(LoginService(memoryUserDatabase))
+		registerService(ZoneService())
+		registerService(CharacterCreationService())
+		registerService(SkillService())
+		registerService(CommandQueueService(5))
+		registerService(CommandExecutionService())
+		registerService(CombatDeathblowService())
+		registerService(ExperiencePointService())
+		registerService(CombatExperienceService())
+
+		memoryUserDatabase.addUser("username", "password")
+	}
+
+	@AfterEach
+	fun tearDown() {
+		memoryUserDatabase.clear()
+	}
 
 	@Test
 	fun `new characters receive a Slitherhorn`() {
-		val character = createCharacter()
+		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
 
-		assertTrue(inventoryContainsSlitherhorn(character))
+		assertTrue(inventoryContainsSlitherhorn(character.player.creatureObject))
+	}
+
+	@Test
+	fun `new characters become Novice in all basic professions`() {
+		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
+
+		val skills = character.player.creatureObject.skills
+		assertAll(
+			{ assertTrue(skills.contains("combat_brawler_novice")) },
+			{ assertTrue(skills.contains("combat_marksman_novice")) },
+			{ assertTrue(skills.contains("crafting_artisan_novice")) },
+			{ assertTrue(skills.contains("science_medic_novice")) },
+			{ assertTrue(skills.contains("outdoors_scout_novice")) },
+			{ assertTrue(skills.contains("social_entertainer_novice")) },
+		)
+	}
+
+	@Test
+	fun `new characters receive their species skill`() {
+		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
+
+		assertTrue(character.player.creatureObject.skills.contains("species_human"))
 	}
 
 	private fun inventoryContainsSlitherhorn(character: CreatureObject): Boolean {
@@ -34,19 +88,4 @@ class CharacterCreationTest : TestRunnerSynchronousIntents() {
 
 	private fun isSlitherhorn(containedObject: SWGObject) = containedObject.template == "object/tangible/instrument/shared_slitherhorn.iff"
 
-	private fun createCharacter(): CreatureObject {
-		val player = GenericPlayer()
-		val clientCreateCharacter = ClientCreateCharacter()
-		clientCreateCharacter.biography = ""
-		clientCreateCharacter.clothes = "combat_brawler"
-		clientCreateCharacter.race = "object/creature/player/shared_human_male.iff"
-		clientCreateCharacter.name = "Testing Character"
-		val characterCreation = CharacterCreation(player, clientCreateCharacter)
-
-		val mosEisley = DataLoader.zoneInsertions().getInsertion("tat_moseisley")
-		val creatureObject = characterCreation.createCharacter(AccessLevel.PLAYER, mosEisley)
-		creatureObject.owner = player
-
-		return creatureObject
-	}
 }


### PR DESCRIPTION
I wanted to write automated tests to cover Scouts getting Trapping XP by killing creatures, but obviously we're not making anyone a Novice Scout right out of the gate now.
Rather than adding some tech debt in the test cases by explicitly making the characters a Novice Scout, I figured re-enabling this made more sense.