### PR TITLE
Renamed IntegrationTest to AcceptanceTest

### DIFF
--- a/src/test/java/com/projectswg/holocore/resources/support/global/zone/creation/CharacterCreationTest.kt
+++ b/src/test/java/com/projectswg/holocore/resources/support/global/zone/creation/CharacterCreationTest.kt
@@ -3,13 +3,13 @@ package com.projectswg.holocore.resources.support.global.zone.creation
 import com.projectswg.holocore.headless.HeadlessSWGClient
 import com.projectswg.holocore.resources.support.objects.swg.SWGObject
 import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject
-import com.projectswg.holocore.test.runners.IntegrationTest
+import com.projectswg.holocore.test.runners.AcceptanceTest
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class CharacterCreationTest : IntegrationTest() {
+class CharacterCreationTest : AcceptanceTest() {
 
 	@BeforeEach
 	fun setUpUser() {

--- a/src/test/java/com/projectswg/holocore/services/gameplay/combat/loot/LootTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/combat/loot/LootTest.kt
@@ -29,11 +29,11 @@ package com.projectswg.holocore.services.gameplay.combat.loot
 import com.projectswg.holocore.headless.HeadlessSWGClient.Companion.createZonedInCharacter
 import com.projectswg.holocore.headless.attack
 import com.projectswg.holocore.headless.loot
-import com.projectswg.holocore.test.runners.IntegrationTest
+import com.projectswg.holocore.test.runners.AcceptanceTest
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
-class LootTest : IntegrationTest() {
+class LootTest : AcceptanceTest() {
 	
 	@Test
 	fun itemsAreGenerated() {

--- a/src/test/java/com/projectswg/holocore/services/gameplay/player/TipCreditsTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/player/TipCreditsTest.kt
@@ -29,11 +29,11 @@ package com.projectswg.holocore.services.gameplay.player
 import com.projectswg.common.data.location.Terrain
 import com.projectswg.holocore.headless.*
 import com.projectswg.holocore.resources.support.global.player.AccessLevel
-import com.projectswg.holocore.test.runners.IntegrationTest
+import com.projectswg.holocore.test.runners.AcceptanceTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
-class TipCreditsTest : IntegrationTest() {
+class TipCreditsTest : AcceptanceTest() {
 
 	@Test
 	fun negativeAmount() {

--- a/src/test/java/com/projectswg/holocore/services/gameplay/player/experience/AdminCommandAccessTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/player/experience/AdminCommandAccessTest.kt
@@ -30,12 +30,12 @@ import com.projectswg.holocore.headless.CommandFailedException
 import com.projectswg.holocore.headless.HeadlessSWGClient
 import com.projectswg.holocore.headless.adminGrantSkill
 import com.projectswg.holocore.resources.support.global.player.AccessLevel
-import com.projectswg.holocore.test.runners.IntegrationTest
+import com.projectswg.holocore.test.runners.AcceptanceTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 
-class AdminCommandAccessTest : IntegrationTest() {
+class AdminCommandAccessTest : AcceptanceTest() {
 
 	@Test
 	fun adminsCanUseAdminCommands() {

--- a/src/test/java/com/projectswg/holocore/services/gameplay/player/experience/SkillTreeTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/player/experience/SkillTreeTest.kt
@@ -30,12 +30,12 @@ import com.projectswg.holocore.headless.HeadlessSWGClient
 import com.projectswg.holocore.headless.adminGrantSkill
 import com.projectswg.holocore.headless.surrenderSkill
 import com.projectswg.holocore.resources.support.global.player.AccessLevel
-import com.projectswg.holocore.test.runners.IntegrationTest
+import com.projectswg.holocore.test.runners.AcceptanceTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class SkillTreeTest : IntegrationTest() {
+class SkillTreeTest : AcceptanceTest() {
 
 	@BeforeEach
 	fun setUp() {

--- a/src/test/java/com/projectswg/holocore/services/gameplay/player/experience/TrappingXPTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/player/experience/TrappingXPTest.kt
@@ -28,13 +28,13 @@ package com.projectswg.holocore.services.gameplay.player.experience
 
 import com.projectswg.holocore.headless.*
 import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject
-import com.projectswg.holocore.test.runners.IntegrationTest
+import com.projectswg.holocore.test.runners.AcceptanceTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class TrappingXPTest : IntegrationTest() {
+class TrappingXPTest : AcceptanceTest() {
 
 	@BeforeEach
 	fun setUpUser() {

--- a/src/test/java/com/projectswg/holocore/services/gameplay/player/group/GroupTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/player/group/GroupTest.kt
@@ -27,11 +27,11 @@
 package com.projectswg.holocore.services.gameplay.player.group
 
 import com.projectswg.holocore.headless.*
-import com.projectswg.holocore.test.runners.IntegrationTest
+import com.projectswg.holocore.test.runners.AcceptanceTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
-class GroupTest : IntegrationTest() {
+class GroupTest : AcceptanceTest() {
 
 	@Test
 	fun formGroup() {

--- a/src/test/java/com/projectswg/holocore/services/support/CharacterManagementTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/support/CharacterManagementTest.kt
@@ -27,13 +27,13 @@
 package com.projectswg.holocore.services.support
 
 import com.projectswg.holocore.headless.HeadlessSWGClient
-import com.projectswg.holocore.test.runners.IntegrationTest
+import com.projectswg.holocore.test.runners.AcceptanceTest
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
-class CharacterManagementTest : IntegrationTest() {
+class CharacterManagementTest : AcceptanceTest() {
 
 	@Test
 	fun deleteCharacter() {

--- a/src/test/java/com/projectswg/holocore/services/support/KillAdminCommandTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/support/KillAdminCommandTest.kt
@@ -31,11 +31,11 @@ import com.projectswg.holocore.headless.HeadlessSWGClient
 import com.projectswg.holocore.headless.adminKill
 import com.projectswg.holocore.resources.support.data.server_info.loader.npc.NpcStaticSpawnLoader
 import com.projectswg.holocore.resources.support.global.player.AccessLevel
-import com.projectswg.holocore.test.runners.IntegrationTest
+import com.projectswg.holocore.test.runners.AcceptanceTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
-class KillAdminCommandTest : IntegrationTest() {
+class KillAdminCommandTest : AcceptanceTest() {
 
 	@Test
 	fun killNpc() {

--- a/src/test/java/com/projectswg/holocore/services/support/LoginTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/support/LoginTest.kt
@@ -30,12 +30,12 @@ import com.projectswg.holocore.headless.AccountBannedException
 import com.projectswg.holocore.headless.HeadlessSWGClient
 import com.projectswg.holocore.headless.WrongClientVersionException
 import com.projectswg.holocore.headless.WrongCredentialsException
-import com.projectswg.holocore.test.runners.IntegrationTest
+import com.projectswg.holocore.test.runners.AcceptanceTest
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
-class LoginTest : IntegrationTest() {
+class LoginTest : AcceptanceTest() {
 
 	@Test
 	fun validCredentials() {

--- a/src/test/java/com/projectswg/holocore/test/runners/AcceptanceTest.kt
+++ b/src/test/java/com/projectswg/holocore/test/runners/AcceptanceTest.kt
@@ -63,12 +63,15 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 
 /**
- * Integration test runner that sets up all the services required for a full integration test.
+ * Acceptance test runner that sets up all the services required for an acceptance test.
  * This includes all the services required for a character to be able to log in and perform actions.
  *
- * Integrations tests should be using [com.projectswg.holocore.headless.HeadlessSWGClient] to perform actions.
+ * Read more about acceptance test-driven development here:
+ * https://en.wikipedia.org/wiki/Acceptance_test-driven_development
+ *
+ * Acceptance tests should be using [com.projectswg.holocore.headless.HeadlessSWGClient] to perform actions.
  */
-abstract class IntegrationTest : TestRunnerSynchronousIntents() {
+abstract class AcceptanceTest : TestRunnerSynchronousIntents() {
 
 	private val memoryUserDatabase = MemoryUserDatabase()
 


### PR DESCRIPTION
I realized "IntegrationTest" wasn't a very accurate name for what the class is being used for.
The subclasses are actually more like acceptance tests than they are like integration tests - thus, the rename.