### PR TITLE
Specified JDK distribution parameter, so actions/setup-java can be bumped

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         submodules: true
     - name: Set up JDK 21
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: 21
     - name: Test with Gradle

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,6 +20,7 @@ jobs:
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
+        distribution: 'temurin'
         java-version: 21
     - name: Test with Gradle
       run: ./gradlew --no-daemon test


### PR DESCRIPTION
Includes the change in #1447 generated by Dependabot and fixes a breaking change.
That PR should become obsolete.