### PR TITLE
Reduced flakiness of GroupTest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,7 @@ dependencies {
 	utilityImplementation(project(":"))
 	utilityImplementation(project(":pswgcommon"))
 	
-	val junit5Version = "5.9.3"
+	val junit5Version = "5.10.1"
 	testImplementation(group="org.junit.jupiter", name="junit-jupiter-api", version= junit5Version)
 	testRuntimeOnly(group="org.junit.jupiter", name="junit-jupiter-engine", version= junit5Version)
 	testImplementation(group="org.junit.jupiter", name="junit-jupiter-params", version= junit5Version)

--- a/src/test/java/com/projectswg/holocore/headless/grouping.kt
+++ b/src/test/java/com/projectswg/holocore/headless/grouping.kt
@@ -27,7 +27,6 @@
 package com.projectswg.holocore.headless
 
 import com.projectswg.common.network.packets.swg.zone.chat.ChatSystemMessage
-import com.projectswg.common.network.packets.swg.zone.deltas.DeltasMessage
 import com.projectswg.holocore.resources.support.objects.swg.group.GroupObject
 import com.projectswg.holocore.services.support.objects.ObjectStorageService
 import java.util.concurrent.TimeUnit
@@ -39,22 +38,25 @@ fun ZonedInCharacter.invitePlayerToGroup(other: ZonedInCharacter) {
 
 fun ZonedInCharacter.acceptCurrentGroupInvitation() {
 	sendCommand("join")
-	player.waitForNextPacket(DeltasMessage::class.java, 50, TimeUnit.MILLISECONDS) ?: java.lang.IllegalStateException("Packet not received")
+	player.waitForNextObjectDelta(player.creatureObject.objectId, 50, TimeUnit.MILLISECONDS) ?: java.lang.IllegalStateException("Packet not received")
 }
 
 fun ZonedInCharacter.leaveCurrentGroup() {
+	val groupObjectId = player.creatureObject.groupId
 	sendCommand("leaveGroup")
-	player.waitForNextPacket(DeltasMessage::class.java, 50, TimeUnit.MILLISECONDS) ?: java.lang.IllegalStateException("Packet not received")
+	player.waitForNextObjectDelta(groupObjectId, 50, TimeUnit.MILLISECONDS) ?: java.lang.IllegalStateException("Packet not received")
 }
 
 fun ZonedInCharacter.kickFromGroup(other: ZonedInCharacter) {
+	val groupObjectId = player.creatureObject.groupId
 	sendCommand("dismissGroupMember", other.player.creatureObject)
-	player.waitForNextPacket(ChatSystemMessage::class.java, 50, TimeUnit.MILLISECONDS) ?: java.lang.IllegalStateException("Packet not received")
+	player.waitForNextObjectDelta(groupObjectId, 50, TimeUnit.MILLISECONDS) ?: java.lang.IllegalStateException("Packet not received")
 }
 
 fun ZonedInCharacter.makeGroupLeader(other: ZonedInCharacter) {
+	val groupObjectId = player.creatureObject.groupId
 	sendCommand("makeLeader", other.player.creatureObject)
-	player.waitForNextPacket(DeltasMessage::class.java, 50, TimeUnit.MILLISECONDS) ?: java.lang.IllegalStateException("Packet not received")
+	player.waitForNextObjectDelta(groupObjectId, 50, TimeUnit.MILLISECONDS) ?: java.lang.IllegalStateException("Packet not received")
 }
 
 fun ZonedInCharacter.isInGroupWith(other: ZonedInCharacter): Boolean {

--- a/src/test/java/com/projectswg/holocore/test/resources/GenericPlayer.java
+++ b/src/test/java/com/projectswg/holocore/test/resources/GenericPlayer.java
@@ -345,13 +345,13 @@ public class GenericPlayer extends Player {
 	}
 	
 	private void handleUpdateCellPermission(UpdateCellPermissionMessage p) {
-		assertTrue(objects.get(p.getCellId()) instanceof CellObject);
+		assertInstanceOf(CellObject.class, objects.get(p.getCellId()));
 	}
 	
 	private void handleUpdatePvpStatusMessage(UpdatePvpStatusMessage p) {
 		SWGObject obj = objects.get(p.getObjectId());
 		assertNotNull(obj);
-		assertTrue(obj instanceof CreatureObject);
+		assertInstanceOf(CreatureObject.class, obj);
 		((CreatureObject) obj).setFaction(ServerData.INSTANCE.getFactions().getFaction(p.getPlayerFaction().name().toLowerCase(Locale.US)));
 		((CreatureObject) obj).setPvpFlags(p.getPvpFlags());
 	}
@@ -368,7 +368,7 @@ public class GenericPlayer extends Player {
 	private void handleUpdatePosture(UpdatePostureMessage p) {
 		SWGObject obj = objects.get(p.getObjectId());
 		assertNotNull(obj);
-		assertTrue(obj instanceof CreatureObject);
+		assertInstanceOf(CreatureObject.class, obj);
 		Posture posture = Posture.getFromId(p.getPosture());
 		assertNotNull(posture);
 		assertNotEquals(Posture.INVALID, posture);


### PR DESCRIPTION
Should help with the group test failure we saw in #1467.
We were listening for deltas relating to all objects - now we're listening for deltas relating to specific objects.