### PR TITLE
Replaced two usages of a deprecated Gradle API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,8 +101,8 @@ jlink {
 //	addOptions("--strip-debug", "--compress", "2", "--no-header-files", "--no-man-pages")
 	addOptions("--ignore-signing-information")
 	forceMerge("kotlin-stdlib")
-	imageDir.set(file("$buildDir/holocore"))
-	imageZip.set(file("$buildDir/holocore.zip"))
+	imageDir.set(layout.buildDirectory.dir("holocore"))
+	imageZip.set(layout.buildDirectory.file("holocore.zip"))
 	launcher {
 		name = "holocore"
 		jvmArgs = listOf()


### PR DESCRIPTION
Warnings:
![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/25e429a7-bc78-43aa-9649-81759200e31b)

Running the jlink builds still outputs to the desired dirs. We just use the new Gradle API to declare those same locations.
![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/448b7db9-d703-43cf-a8ef-bb28c6d899be)
