### PR TITLE
[Quest] Play music on quest task activation and completion

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/QuestLoader.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/QuestLoader.java
@@ -156,6 +156,18 @@ public class QuestLoader extends DataLoader {
 				if (columns.contains("loot_drop_percent")) {
 					lootDropPercent = (int) set.getInt("loot_drop_percent");
 				}
+				String musicOnActivate = null;
+				if (columns.contains("music_on_activate")) {
+					musicOnActivate = set.getText("music_on_activate");
+				}
+				String musicOnComplete = null;
+				if (columns.contains("music_on_complete")) {
+					musicOnComplete = set.getText("music_on_complete");
+				}
+				String musicOnFailure = null;
+				if (columns.contains("music_on_failure")) {
+					musicOnFailure = set.getText("music_on_failure");
+				}
 				
 				QuestTaskInfo questTaskInfo = new QuestTaskInfo();
 				
@@ -193,7 +205,10 @@ public class QuestLoader extends DataLoader {
 				questTaskInfo.setLootItemName(lootItemName);
 				questTaskInfo.setLootItemsRequired(lootItemsRequired);
 				questTaskInfo.setLootDropPercent(lootDropPercent);
-				
+				questTaskInfo.setMusicOnActivate(musicOnActivate);
+				questTaskInfo.setMusicOnComplete(musicOnComplete);
+				questTaskInfo.setMusicOnFailure(musicOnFailure);
+
 				questTaskInfos.add(questTaskInfo);
 			}
 		} catch (Exception e) {
@@ -307,7 +322,10 @@ public class QuestLoader extends DataLoader {
 		private String lootItemName;
 		private int lootItemsRequired;
 		private int lootDropPercent;
-		
+		private String musicOnActivate;
+		private String musicOnComplete;
+		private String musicOnFailure;
+
 		private QuestTaskInfo() {
 			nextTasksOnComplete = new ArrayList<>();
 		}
@@ -527,6 +545,30 @@ public class QuestLoader extends DataLoader {
 		
 		public void setGrantQuestOnComplete(String grantQuestOnComplete) {
 			this.grantQuestOnComplete = grantQuestOnComplete;
+		}
+
+		public String getMusicOnActivate() {
+			return musicOnActivate;
+		}
+
+		public void setMusicOnActivate(String musicOnActivate) {
+			this.musicOnActivate = musicOnActivate;
+		}
+
+		public String getMusicOnComplete() {
+			return musicOnComplete;
+		}
+
+		public void setMusicOnComplete(String musicOnComplete) {
+			this.musicOnComplete = musicOnComplete;
+		}
+
+		public String getMusicOnFailure() {
+			return musicOnFailure;
+		}
+
+		public void setMusicOnFailure(String musicOnFailure) {
+			this.musicOnFailure = musicOnFailure;
 		}
 
 		@Override

--- a/src/main/java/com/projectswg/holocore/services/gameplay/player/quest/QuestService.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/player/quest/QuestService.kt
@@ -89,11 +89,10 @@ class QuestService(private val destroyMultiAndLootDie: Die = RandomDie()) : Serv
 			return
 		}
 		playerObject.addQuest(questName)
-		playerObject.addActiveQuestTask(questName, 0)
 		StandardLog.onPlayerTrace(this, player, "received quest %s", questName)
-		handleTaskEvents(player, questName)
 		val prose = ProsePackage(StringId("quest/ground/system_message", "quest_received"), "TO", questListInfo.journalEntryTitle)
 		SystemMessageIntent.broadcastPersonal(player, prose, ChatSystemMessage.SystemChatType.QUEST)
+		activateTask(player, questName, questLoader.getTaskListInfos(questName)[0])
 	}
 
 	@IntentHandler
@@ -161,7 +160,7 @@ class QuestService(private val destroyMultiAndLootDie: Die = RandomDie()) : Serv
 			StandardLog.onPlayerTrace(this, owner, "acquired %d/%d %s on task %d of quest %s", counter, max, activeTaskListInfo.lootItemName, task, questName)
 			incrementKillItemCount(questName, task, owner, counter, max, activeTaskListInfo.lootItemName)
 			if (remaining <= 0) {
-				advanceQuest(questName, owner, activeTaskListInfo)
+				completeTask(questName, owner, activeTaskListInfo)
 			}
 		} else {
 			StandardLog.onPlayerTrace(this, owner, "failed to acquire '%s' on task %d of quest %s", activeTaskListInfo.lootItemName, activeTaskListInfo.index, questName)
@@ -182,7 +181,7 @@ class QuestService(private val destroyMultiAndLootDie: Die = RandomDie()) : Serv
 		StandardLog.onPlayerTrace(this, owner, "acquired %d/%d kills on task %d of quest %s", counter, max, task, questName)
 		incrementKillCount(questName, task, owner, counter, max)
 		if (remaining <= 0) {
-			advanceQuest(questName, owner, activeTaskListInfo)
+			completeTask(questName, owner, activeTaskListInfo)
 		}
 	}
 
@@ -217,30 +216,8 @@ class QuestService(private val destroyMultiAndLootDie: Die = RandomDie()) : Serv
 		SystemMessageIntent.broadcastPersonal(player, prose)
 	}
 
-	private fun handleTaskEvents(player: Player, questName: String) {
-		val playerObject = player.getPlayerObject()
-		val currentTasks = getActiveTaskInfos(questName, playerObject)
-		for (currentTask in currentTasks) {
-			val type = currentTask.type ?: continue
-			if (currentTask.isVisible) {
-				player.sendPacket(PlayMusicMessage(0, "sound/ui_journal_updated.snd", 1, false))
-			}
-
-			when (type) {
-				"quest.task.ground.comm_player"            -> handleCommPlayer(player, questName, currentTask)
-				"quest.task.ground.complete_quest"         -> completeQuest(player, questName)
-				"quest.task.ground.timer"                  -> handleTimer(player, questName, currentTask)
-				"quest.task.ground.show_message_box"       -> handleShowMessageBox(player, questName, currentTask)
-				"quest.task.ground.destroy_multi"          -> handleDestroyMulti(player, questName, currentTask)
-				"quest.task.ground.destroy_multi_and_loot" -> handleDestroyMultiAndLoot(player, questName, currentTask)
-				"quest.task.ground.reward"                 -> handleReward(player, questName, playerObject, currentTask)
-				"quest.task.ground.nothing"                -> handleNothing(player, questName, currentTask)
-			}
-		}
-	}
-
 	private fun handleNothing(player: Player, questName: String, currentTask: QuestTaskInfo) {
-		advanceQuest(questName, player, currentTask)
+		completeTask(questName, player, currentTask)
 	}
 
 	private fun handleReward(player: Player, questName: String, playerObject: PlayerObject, currentTask: QuestTaskInfo) {
@@ -252,7 +229,7 @@ class QuestService(private val destroyMultiAndLootDie: Die = RandomDie()) : Serv
 		// weapon stuff: weapon	count_weapon	speed	damage	efficiency	elemental_value
 		// armor stuff: armor	count_armor	quality
 		// speed etc. are percentages, the absolute values we must define somewhere else before we can hand out weapons and armor rewards
-		advanceQuest(questName, player, currentTask)
+		completeTask(questName, player, currentTask)
 	}
 
 	private fun handleShowMessageBox(player: Player, questName: String, currentTask: QuestTaskInfo) {
@@ -262,7 +239,7 @@ class QuestService(private val destroyMultiAndLootDie: Die = RandomDie()) : Serv
 		sui.setSize(384, 256)
 		sui.setLocation(320, 256)
 		sui.display(player)
-		advanceQuest(questName, player, currentTask)
+		completeTask(questName, player, currentTask)
 	}
 
 	private fun handleCommPlayer(player: Player, questName: String, currentTask: QuestTaskInfo) {
@@ -271,7 +248,7 @@ class QuestService(private val destroyMultiAndLootDie: Die = RandomDie()) : Serv
 		val objectId = player.creatureObject.objectId
 		val modelCrc = getModelCrc(currentTask)
 		player.sendPacket(CommPlayerMessage(objectId, message, modelCrc, "", 10f))
-		advanceQuest(questName, player, currentTask)
+		completeTask(questName, player, currentTask)
 	}
 
 	private fun handleTimer(player: Player, questName: String, currentTask: QuestTaskInfo) {
@@ -283,7 +260,7 @@ class QuestService(private val destroyMultiAndLootDie: Die = RandomDie()) : Serv
 		executor.execute(delayMilliseconds.toLong()) {	// TODO if the server is restarted, the timer will be lost and the quest will be stuck
 			if (player.playerObject.isQuestInJournal(questName)) {
 				StandardLog.onPlayerTrace(this, player, "timer for task %d of quest %s expired", currentTask.index, questName)
-				advanceQuest(questName, player, currentTask)
+				completeTask(questName, player, currentTask)
 			}
 		}
 
@@ -299,7 +276,31 @@ class QuestService(private val destroyMultiAndLootDie: Die = RandomDie()) : Serv
 		}
 	}
 
-	private fun advanceQuest(questName: String, player: Player, currentTask: QuestTaskInfo) {
+	private fun activateTask(player: Player, questName: String, currentTask: QuestTaskInfo) {
+		StandardLog.onPlayerTrace(this, player, "activating task %d of quest %s", currentTask.index, questName)
+		val playerObject = player.getPlayerObject()
+		playerObject.addActiveQuestTask(questName, currentTask.index)
+		if (currentTask.isVisible) {
+			player.sendPacket(PlayMusicMessage(0, "sound/ui_journal_updated.snd", 1, false))
+
+			if (currentTask.musicOnActivate != null && currentTask.musicOnActivate.isNotBlank()) {
+				player.sendPacket(PlayMusicMessage(0, currentTask.musicOnActivate, 1, false))
+			}
+		}
+
+		when (currentTask.type) {
+			"quest.task.ground.comm_player"            -> handleCommPlayer(player, questName, currentTask)
+			"quest.task.ground.complete_quest"         -> completeQuest(player, questName)
+			"quest.task.ground.timer"                  -> handleTimer(player, questName, currentTask)
+			"quest.task.ground.show_message_box"       -> handleShowMessageBox(player, questName, currentTask)
+			"quest.task.ground.destroy_multi"          -> handleDestroyMulti(player, questName, currentTask)
+			"quest.task.ground.destroy_multi_and_loot" -> handleDestroyMultiAndLoot(player, questName, currentTask)
+			"quest.task.ground.reward"                 -> handleReward(player, questName, playerObject, currentTask)
+			"quest.task.ground.nothing"                -> handleNothing(player, questName, currentTask)
+		}
+	}
+
+	private fun completeTask(questName: String, player: Player, currentTask: QuestTaskInfo) {
 		val playerObject = player.getPlayerObject()
 		playerObject.removeActiveQuestTask(questName, currentTask.index)
 		playerObject.addCompleteQuestTask(questName, currentTask.index)
@@ -308,13 +309,16 @@ class QuestService(private val destroyMultiAndLootDie: Die = RandomDie()) : Serv
 			broadcast(player, grantQuestOnComplete)
 		}
 
-		val nextTasksOnComplete = currentTask.nextTasksOnComplete
-		StandardLog.onPlayerTrace(this, player, "completed task %d of quest %s, activating next tasks [%s]", currentTask.index, questName, nextTasksOnComplete.joinToString(separator = ","))
-		nextTasksOnComplete.forEach { playerObject.addActiveQuestTask(questName, it) }
+		if (currentTask.musicOnComplete != null && currentTask.musicOnComplete.isNotBlank()) {
+			player.sendPacket(PlayMusicMessage(0, currentTask.musicOnComplete, 1, false))
+		}
 
-		handleTaskEvents(player, questName)
+		val nextTasksIdsOnComplete = currentTask.nextTasksOnComplete
+		val nextTasksOnComplete = questLoader.getTaskListInfos(questName)
+		StandardLog.onPlayerTrace(this, player, "completed task %d of quest %s", currentTask.index, questName)
+		nextTasksIdsOnComplete.forEach { activateTask(player, questName, nextTasksOnComplete[it]) }
 
-		if (nextTasksOnComplete.isEmpty()) {
+		if (nextTasksIdsOnComplete.isEmpty()) {
 			if (questLoader.getQuestListInfo(questName).isCompleteWhenTasksComplete) {
 				completeQuest(player, questName)
 			}


### PR DESCRIPTION
Relates to #1460.
There's currently no way a quest can fail, so music_on_failure is loaded but not used right now.

I refactored `QuestService` a bit, because:
* ... the function name `advanceQuest` didn't really match the language used in the SDBs etc. (we don't "advance" a quest - we complete tasks)
* ... code for activating a task was duplicated - now it's in a function, where music-on-task-activation has been inserted
* ... the flow was still a bit difficult to understand with `handleTaskEvents`, where it relied on some state being modified beforehand