### PR TITLE
Fixed exploration badges

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/ExplorationBadgeLoader.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/ExplorationBadgeLoader.kt
@@ -54,8 +54,8 @@ class ExplorationBadgeLoader : DataLoader() {
 	class ExplorationBadgeInfo(set: SdbLoader.SdbResultSet) {
 		val x = set.getInt("x")
 		val y = set.getInt("y")
-		val radius = set.getInt("y")
-		val badgeSlot = set.getInt("y")
+		val radius = set.getInt("radius")
+		val badgeSlot = set.getInt("badge_slot")
 		val badgeName = set.getText("badge_name")
 	}
 }

--- a/src/main/java/com/projectswg/holocore/services/gameplay/player/badge/ExplorationBadgeService.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/player/badge/ExplorationBadgeService.kt
@@ -48,12 +48,8 @@ class ExplorationBadgeService : Service() {
 		}
 	}
 	@IntentHandler
-	private fun handleObjectTeleportedIntent(pti: ObjectTeleportIntent) {
-		if (pti.`object` !is CreatureObject)
-			return
-		val creatureObject = pti.`object` as CreatureObject
-		if (!creatureObject.isPlayer)
-			return
+	private fun handleObjectTeleportedIntent(oti: ObjectTeleportIntent) {
+		val creatureObject = oti.`object` as? CreatureObject ?: return
 		val explorationBadgeInfo = checkExplorationRegions(creatureObject) ?: return
 		
 		if (!hasBadge(creatureObject, explorationBadgeInfo)) {

--- a/src/main/java/com/projectswg/holocore/services/gameplay/player/badge/ExplorationBadgeService.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/player/badge/ExplorationBadgeService.kt
@@ -30,6 +30,7 @@ import com.projectswg.common.data.location.Location
 import com.projectswg.common.data.location.Point3D
 import com.projectswg.holocore.intents.gameplay.player.badge.GrantBadgeIntent
 import com.projectswg.holocore.intents.support.global.zone.PlayerTransformedIntent
+import com.projectswg.holocore.intents.support.objects.swg.ObjectTeleportIntent
 import com.projectswg.holocore.resources.support.data.server_info.loader.ExplorationBadgeLoader
 import com.projectswg.holocore.resources.support.data.server_info.loader.ServerData.explorationBadges
 import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject
@@ -40,6 +41,19 @@ class ExplorationBadgeService : Service() {
 	@IntentHandler
 	private fun handlePlayerTransformedIntent(pti: PlayerTransformedIntent) {
 		val creatureObject = pti.player
+		val explorationBadgeInfo = checkExplorationRegions(creatureObject) ?: return
+		
+		if (!hasBadge(creatureObject, explorationBadgeInfo)) {
+			GrantBadgeIntent.broadcast(creatureObject, explorationBadgeInfo.badgeName)
+		}
+	}
+	@IntentHandler
+	private fun handleObjectTeleportedIntent(pti: ObjectTeleportIntent) {
+		if (pti.`object` !is CreatureObject)
+			return
+		val creatureObject = pti.`object` as CreatureObject
+		if (!creatureObject.isPlayer)
+			return
 		val explorationBadgeInfo = checkExplorationRegions(creatureObject) ?: return
 		
 		if (!hasBadge(creatureObject, explorationBadgeInfo)) {

--- a/src/test/java/com/projectswg/holocore/headless/badges.kt
+++ b/src/test/java/com/projectswg/holocore/headless/badges.kt
@@ -1,0 +1,41 @@
+/***********************************************************************************
+ * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.headless
+
+import com.projectswg.common.data.Badges
+import com.projectswg.common.network.packets.swg.zone.BadgesResponseMessage
+
+/**
+ * Requests the badges for the given character.
+ * @param character the character to request badges for (defaults to this character)
+ * @return the badges for the given character
+ */
+fun ZonedInCharacter.requestBadges(character: ZonedInCharacter = this): Badges {
+	sendCommand("requestBadges", character.player.creatureObject)
+	val badgesResponseMessage = player.waitForNextPacket(BadgesResponseMessage::class.java) ?: throw IllegalStateException("Badges not received in time")
+	return badgesResponseMessage.badges
+}

--- a/src/test/java/com/projectswg/holocore/services/gameplay/player/badge/ExplorationBadgeTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/player/badge/ExplorationBadgeTest.kt
@@ -1,0 +1,53 @@
+/***********************************************************************************
+ * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.services.gameplay.player.badge
+
+import com.projectswg.common.data.location.Terrain
+import com.projectswg.holocore.headless.HeadlessSWGClient
+import com.projectswg.holocore.headless.adminTeleport
+import com.projectswg.holocore.headless.requestBadges
+import com.projectswg.holocore.resources.support.global.player.AccessLevel
+import com.projectswg.holocore.test.runners.AcceptanceTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class ExplorationBadgeTest : AcceptanceTest() {
+	@Test
+	fun enteringAreaGrantsBadge() {
+		addUser("Test", "Test", AccessLevel.DEV)
+		val character = HeadlessSWGClient.createZonedInCharacter("Test", "Test", "char")
+
+		character.adminTeleport(planet = Terrain.MUSTAFAR, x = 0, y = 0, z = 0)
+
+		val badges = character.requestBadges()
+		val mustafarExplorationBadgeSlot = 171
+		assertAll(
+			{ assertEquals(1, badges.explorationBadgeCount) },
+			{ assertTrue(badges.hasBadge(mustafarExplorationBadgeSlot)) }
+		)
+	}
+}

--- a/src/test/java/com/projectswg/holocore/test/runners/AcceptanceTest.kt
+++ b/src/test/java/com/projectswg/holocore/test/runners/AcceptanceTest.kt
@@ -41,6 +41,7 @@ import com.projectswg.holocore.services.gameplay.combat.CombatDeathblowService
 import com.projectswg.holocore.services.gameplay.combat.CombatExperienceService
 import com.projectswg.holocore.services.gameplay.combat.loot.GrantLootService
 import com.projectswg.holocore.services.gameplay.combat.loot.LootGenerationService
+import com.projectswg.holocore.services.gameplay.player.badge.BadgeManager
 import com.projectswg.holocore.services.gameplay.player.character.TippingService
 import com.projectswg.holocore.services.gameplay.player.experience.ExperiencePointService
 import com.projectswg.holocore.services.gameplay.player.experience.skills.SkillService
@@ -98,6 +99,7 @@ abstract class AcceptanceTest : TestRunnerSynchronousIntents() {
 		registerService(LootGenerationService(DeterministicDie(1), DeterministicDie(1)))
 		registerService(GrantLootService())
 		registerService(ContainerService())
+		registerService(BadgeManager())
 	}
 
 	@AfterEach


### PR DESCRIPTION
Fixes #1455

I added teleportation handling in `ExplorationBadgeService`, so our tests wouldn't have to actually move the character around with data transforms. I tried going down the movement route, but it was quite complex and didn't really seem worth it after a couple of hours.
I figured this wouldn't hurt to have during real gameplay either.

The added test failed before fixing the problems in `ExplorationBadgeLoader` and passed after.