### PR TITLE
Improved Gradle 9.x compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,9 +78,10 @@ dependencies {
 	utilityImplementation(project(":pswgcommon"))
 	
 	val junit5Version = "5.10.1"
-	testImplementation(group="org.junit.jupiter", name="junit-jupiter-api", version= junit5Version)
-	testRuntimeOnly(group="org.junit.jupiter", name="junit-jupiter-engine", version= junit5Version)
-	testImplementation(group="org.junit.jupiter", name="junit-jupiter-params", version= junit5Version)
+	testImplementation(group="org.junit.jupiter", name="junit-jupiter-api", version=junit5Version)
+	testRuntimeOnly(group="org.junit.jupiter", name="junit-jupiter-engine", version=junit5Version)
+	testRuntimeOnly(group="org.junit.platform", name="junit-platform-launcher", version="1.10.1")
+	testImplementation(group="org.junit.jupiter", name="junit-jupiter-params", version=junit5Version)
 	testImplementation(group="org.testcontainers", name="mongodb", version="1.18.0")
 	testRuntimeOnly(group="org.slf4j", name="slf4j-simple", version="1.7.36")
 


### PR DESCRIPTION
After the recent upgrade of Gradle to 8.5, Gradle has begun warning us of deprecated behavior when running automated tests.

Here's an example snippet:
```
> Task :test
The automatic loading of test framework implementation dependencies has been deprecated. This is scheduled to be removed in Gradle 9.0. Declare the desired test framework directly on the test suite or explicitly declare the test framework implementation dependencies on the test's runtime classpath. Consult the upgrading guide for further information: https://docs.gradle.org/8.5/userguide/upgrading_version_8.html#test_framework_implementation_dependencies
BUILD SUCCESSFUL in 3s
12 actionable tasks: 3 executed, 9 up-to-date
18:10:48: Execution finished ':test --tests "com.projectswg.holocore.services.gameplay.combat.missions.DestroyMissionListTest"'.
```

I followed Gradle's migration guide to fixing the setup we already have by explicitly adding:
`testRuntimeOnly(group="org.junit.platform", name="junit-platform-launcher", version="1.10.1")`

```
> Task :test
BUILD SUCCESSFUL in 3s
12 actionable tasks: 3 executed, 9 up-to-date
18:09:59: Execution finished ':test --tests "com.projectswg.holocore.services.gameplay.combat.missions.DestroyMissionListTest"'.
```

The warning is now gone.