### PR TITLE
ArchUnit rules for testcases

### DIFF
--- a/src/test/java/com/projectswg/holocore/architecture/production/ProductionArchitectureTest.kt
+++ b/src/test/java/com/projectswg/holocore/architecture/production/ProductionArchitectureTest.kt
@@ -24,7 +24,7 @@
  * You should have received a copy of the GNU Affero General Public License        *
  * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
  ***********************************************************************************/
-package com.projectswg.holocore.architecture
+package com.projectswg.holocore.architecture.production
 
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeTests
 import com.tngtech.archunit.junit.AnalyzeClasses
@@ -39,7 +39,7 @@ import me.joshlarson.jlcommon.control.Manager
 import me.joshlarson.jlcommon.control.Service
 
 @AnalyzeClasses(packages = ["com.projectswg.holocore"], importOptions = [DoNotIncludeTests::class])
-class ArchitectureTest {
+class ProductionArchitectureTest {
 
 	@ArchTest
 	val managerSuffixApplied: ArchRule = classes().that()

--- a/src/test/java/com/projectswg/holocore/architecture/testing/AcceptanceTestRules.kt
+++ b/src/test/java/com/projectswg/holocore/architecture/testing/AcceptanceTestRules.kt
@@ -1,0 +1,61 @@
+/***********************************************************************************
+ * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.architecture.testing
+
+import com.projectswg.common.network.packets.SWGPacket
+import com.projectswg.holocore.headless.HeadlessSWGClient
+import com.projectswg.holocore.test.runners.AcceptanceTest
+import com.tngtech.archunit.junit.ArchTest
+import com.tngtech.archunit.lang.ArchRule
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition
+import me.joshlarson.jlcommon.control.Intent
+
+object AcceptanceTestRules {
+	@ArchTest
+	val useHeadlessSwgClient: ArchRule = ArchRuleDefinition.classes().that()
+		.areAssignableTo(AcceptanceTest::class.java)
+		.should()
+		.dependOnClassesThat()
+		.resideInAPackage(HeadlessSWGClient::class.java.packageName)
+		.because("acceptance tests should use the ${HeadlessSWGClient::class.simpleName} to perform actions")
+
+	@ArchTest
+	val doNotDirectlyReferencePackets: ArchRule = ArchRuleDefinition.noClasses().that()
+		.areAssignableTo(AcceptanceTest::class.java)
+		.should()
+		.dependOnClassesThat()
+		.areAssignableTo(SWGPacket::class.java)
+		.because("we want to re-use packet handling from test to test and we centralize this in ${HeadlessSWGClient::class.simpleName}")
+
+	@ArchTest
+	val doNotDirectlyReferenceIntents: ArchRule = ArchRuleDefinition.noClasses().that()
+		.areAssignableTo(AcceptanceTest::class.java)
+		.should()
+		.dependOnClassesThat()
+		.areAssignableTo(Intent::class.java)
+		.because("interact with the server through the ${HeadlessSWGClient::class.simpleName} using packets instead of directly using intents")
+}

--- a/src/test/java/com/projectswg/holocore/architecture/testing/JUnitRules.kt
+++ b/src/test/java/com/projectswg/holocore/architecture/testing/JUnitRules.kt
@@ -1,0 +1,45 @@
+/***********************************************************************************
+ * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.architecture.testing
+
+import com.tngtech.archunit.junit.ArchTest
+import com.tngtech.archunit.lang.ArchRule
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition
+
+object JUnitRules {
+	@ArchTest
+	val doNotUseJUnit4: ArchRule = ArchRuleDefinition.noClasses().should()
+		.dependOnClassesThat()
+		.resideInAPackage("org.junit")
+		.because("we use JUnit 5")
+
+	@ArchTest
+	val doNotUseJUnit3: ArchRule = ArchRuleDefinition.noClasses().should()
+		.dependOnClassesThat()
+		.resideInAPackage("junit.framework")
+		.because("we use JUnit 5")
+}

--- a/src/test/java/com/projectswg/holocore/architecture/testing/TestingArchitectureTest.kt
+++ b/src/test/java/com/projectswg/holocore/architecture/testing/TestingArchitectureTest.kt
@@ -1,0 +1,42 @@
+/***********************************************************************************
+ * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.architecture.testing
+
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.junit.AnalyzeClasses
+import com.tngtech.archunit.junit.ArchTest
+import com.tngtech.archunit.junit.ArchTests
+
+@AnalyzeClasses(packages = ["com.projectswg.holocore"], importOptions = [ImportOption.OnlyIncludeTests::class])
+class TestingArchitectureTest {
+	
+	@ArchTest
+	val acceptanceTestRules: ArchTests = ArchTests.`in`(AcceptanceTestRules::class.java)
+
+	@ArchTest
+	val junitRules: ArchTests = ArchTests.`in`(JUnitRules::class.java)
+}


### PR DESCRIPTION
We have some rules for production code already - this PR introduces a few more, but for the tests of production code.
There are some (unwritten) best practices when it comes to writing tests. I've tried capturing the ones I could think of in ArchRules, so keeping things neat is easier.

All our existing code passes with flying colors (phew... 😅), so I didn't actually have to edit anything.
But for that reason, I had to write some code that broke the rules - using JUnit 3, JUnit 4, instantiating packets and referencing intents in a subclass of `AcceptanceTest`. I've obviously not included that here, but the point is that I've seen the tests both pass and fail when they should.