### PR TITLE
Patch CVE-2023-42503 (minor security vulnerability)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,7 @@ dependencies {
 	testRuntimeOnly(group="org.junit.jupiter", name="junit-jupiter-engine", version=junit5Version)
 	testRuntimeOnly(group="org.junit.platform", name="junit-platform-launcher", version="1.10.1")
 	testImplementation(group="org.junit.jupiter", name="junit-jupiter-params", version=junit5Version)
-	testImplementation(group="org.testcontainers", name="mongodb", version="1.18.0")
+	testImplementation(group="org.testcontainers", name="mongodb", version="1.19.3")
 	testRuntimeOnly(group="org.slf4j", name="slf4j-simple", version="1.7.36")
 
 	testImplementation("com.tngtech.archunit:archunit-junit5:1.2.1")


### PR DESCRIPTION
Patches this minor vulnerability in Holocore: CVE-2023-42503.
Testcontainers depends on Apache Commons Compress and new releases have been made of both libraries that patch the problem.

I discovered it because IntelliJ IDEA has a Checkmarx integration these days that alerted me when I was randomly browsing the build script.

![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/0583537c-c6c4-4832-a2ed-0cfeb2717158)

Maybe there's something we can run periodically to help discover this kind of issue? 🤔 