### PR TITLE
Headless client now sets an actual SocketAddress

### DIFF
--- a/src/test/java/com/projectswg/holocore/headless/HeadlessSWGClient.kt
+++ b/src/test/java/com/projectswg/holocore/headless/HeadlessSWGClient.kt
@@ -34,6 +34,7 @@ import com.projectswg.holocore.intents.support.global.network.InboundPacketInten
 import com.projectswg.holocore.resources.support.global.player.Player.PlayerServer
 import com.projectswg.holocore.resources.support.global.player.PlayerState
 import com.projectswg.holocore.test.resources.GenericPlayer
+import java.net.SocketAddress
 import java.util.concurrent.TimeUnit
 
 /**
@@ -108,7 +109,14 @@ class HeadlessSWGClient(private val username: String, private val version: Strin
 
 }
 
+val socketAddress = object: SocketAddress() {
+	override fun toString(): String {
+		return "localhost"	// Used in logging
+	}
+}
+
 internal fun sendPacket(player: GenericPlayer, packet: SWGPacket) {
+	packet.socketAddress = socketAddress
 	// Currently broadcasts the InboundPacketIntent directly, but this could be changed to send the packet for real
 	InboundPacketIntent.broadcast(player, packet)
 }


### PR DESCRIPTION
It *currently* doesn't mean anything in terms of exceptions. Holocore just logs "null" sometimes.

Here's a snippet of what the log looks like in acceptance tests now:
```
22-12-23 17:23:53.631 D: [LoginService] Playerone logged in from localhost
22-12-23 17:23:53.631 T: [CharacterCreationService] Playerone created player at spawn location tat_moseisley
22-12-23 17:23:53.632 D: [CharacterCreationService] Playerone created character 'Charone' from localhost
22-12-23 17:23:53.633 D: [ZoneService] Playerone/Charone connected to zone server from localhost
```
