### PR TITLE
Bumped mongodb driver in order to patch CVE-2021-20328

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,12 +68,14 @@ dependencies {
 	implementation(project(":pswgcommon"))
 	implementation(kotlin("stdlib"))
 	implementation(kotlin("reflect"))
-	implementation(group="org.mongodb", name="mongodb-driver-sync", version="3.12.2")
+	implementation(group="org.mongodb", name="mongodb-driver-sync", version="4.11.1")
 	implementation(group="me.joshlarson", name="fast-json", version="3.0.1")
 	implementation(group="me.joshlarson", name="jlcommon-network", version="1.1.0")
 	implementation(group="me.joshlarson", name="jlcommon-argparse", version="0.9.6")
 	implementation(group="me.joshlarson", name="websocket", version="0.9.4")
-	
+	val slf4jVersion = "1.7.36"
+	runtimeOnly(group="org.slf4j", name="slf4j-jdk14", version= slf4jVersion)
+
 	utilityImplementation(project(":"))
 	utilityImplementation(project(":pswgcommon"))
 	
@@ -83,7 +85,6 @@ dependencies {
 	testRuntimeOnly(group="org.junit.platform", name="junit-platform-launcher", version="1.10.1")
 	testImplementation(group="org.junit.jupiter", name="junit-jupiter-params", version=junit5Version)
 	testImplementation(group="org.testcontainers", name="mongodb", version="1.19.3")
-	testRuntimeOnly(group="org.slf4j", name="slf4j-simple", version="1.7.36")
 
 	testImplementation("com.tngtech.archunit:archunit-junit5:1.2.1")
 }


### PR DESCRIPTION
Patches minor vulnerability CVE-2021-20328.

I've been through the release notes of the mongodb driver and the only thing I've found that affects the codebase is the fact that java.util.logging has been replaced with SLF4J.
For that reason I had to twiddle with the SLF4J dependency a bit. It's no longer just for the Testcontainers library during testing, it's now also for the mongodb driver.

We have this bit of code in `PswgDatabase`:

```kotlin
private fun setupMongoLogging() {
	var mongoLogger: Logger? = Logger.getLogger("com.mongodb")
	while (mongoLogger != null) {
		for (handler in mongoLogger.handlers) {
			mongoLogger.removeHandler(handler)
		}
		if (mongoLogger.parent != null)
			mongoLogger = mongoLogger.parent
		else
			break
	}
	mongoLogger?.addHandler(object : Handler() {
		override fun publish(record: LogRecord) {
			when (record.level) {
				Level.INFO -> Log.i("MongoDB: %s", record.message)
				Level.WARNING -> Log.w("MongoDB: %s", record.message)
				Level.SEVERE -> Log.e("MongoDB: %s", record.message)
				else -> Log.t("MongoDB: %s", record.message)
			}
		}
		
		override fun flush() {}
		override fun close() {}
	})
}
```

This code expects the mongodb driver loggers to be using java.util.logging. I simply installed a SLF4J bridge for java.util.logging and it worked again.

```
> Task :runProduction
23-12-23 04:45:32.826 I: MongoDB: MongoClient with metadata {"driver": {"name": "mongo-java-driver|sync", "version": "4.11.1"}, "os": {"type": "Darwin", "name": "Mac OS X", "architecture": "aarch64", "version": "14.2.1"}, "platform": "Java/Eclipse Adoptium/21.0.1+12-LTS"} created with settings MongoClientSettings{readPreference=primary, writeConcern=WriteConcern{w=null, wTimeout=null ms, journal=null}, retryWrites=true, retryReads=true, readConcern=ReadConcern{level=null}, credential=null, transportSettings=null, streamFactoryFactory=null, commandListeners=[], codecRegistry=ProvidersCodecRegistry{codecProviders=[ValueCodecProvider{}, BsonValueCodecProvider{}, DBRefCodecProvider{}, DBObjectCodecProvider{}, DocumentCodecProvider{}, CollectionCodecProvider{}, IterableCodecProvider{}, MapCodecProvider{}, GeoJsonCodecProvider{}, GridFSFileCodecProvider{}, Jsr310CodecProvider{}, JsonObjectCodecProvider{}, BsonCodecProvider{}, EnumCodecProvider{}, com.mongodb.client.model.mql.ExpressionCodecProvider@5e57cc6b, com.mongodb.Jep395RecordCodecProvider@50130319, com.mongodb.KotlinCodecProvider@709ff45c]}, loggerSettings=LoggerSettings{maxDocumentLength=1000}, clusterSettings={hosts=[localhost:27017], srvServiceName=mongodb, mode=SINGLE, requiredClusterType=UNKNOWN, requiredReplicaSetName='null', serverSelector='null', clusterListeners='[]', serverSelectionTimeout='30000 ms', localThreshold='15 ms'}, socketSettings=SocketSettings{connectTimeoutMS=10000, readTimeoutMS=0, receiveBufferSize=0, proxySettings=ProxySettings{host=null, port=null, username=null, password=null}}, heartbeatSocketSettings=SocketSettings{connectTimeoutMS=10000, readTimeoutMS=10000, receiveBufferSize=0, proxySettings=ProxySettings{host=null, port=null, username=null, password=null}}, connectionPoolSettings=ConnectionPoolSettings{maxSize=100, minSize=0, maxWaitTimeMS=120000, maxConnectionLifeTimeMS=0, maxConnectionIdleTimeMS=0, maintenanceInitialDelayMS=0, maintenanceFrequencyMS=60000, connectionPoolListeners=[], maxConnecting=2}, serverSettings=ServerSettings{heartbeatFrequencyMS=10000, minHeartbeatFrequencyMS=500, serverListeners='[]', serverMonitorListeners='[]'}, sslSettings=SslSettings{enabled=false, invalidHostNameAllowed=false, context=null}, applicationName='null', compressorList=[], uuidRepresentation=UNSPECIFIED, serverApi=null, autoEncryptionSettings=null, dnsClient=null, inetAddressResolver=null, contextProvider=null}
23-12-23 04:45:32.857 I: MongoDB: Exception in monitor thread while connecting to server localhost:27017
23-12-23 04:45:32.886 I: MongoDB: No server chosen by ReadPreferenceServerSelector{readPreference=primary} from cluster description ClusterDescription{type=UNKNOWN, connectionMode=SINGLE, serverDescriptions=[ServerDescription{address=localhost:27017, type=UNKNOWN, state=CONNECTING, exception={com.mongodb.MongoSocketReadException: Exception receiving message}, caused by {java.net.SocketException: Connection reset}}]}. Waiting for 30000 ms before timing out
23-12-23 04:45:34.373 I: MongoDB: Monitor thread successfully connected to server with description ServerDescription{address=localhost:27017, type=STANDALONE, state=CONNECTED, ok=true, minWireVersion=0, maxWireVersion=13, maxDocumentSize=16777216, logicalSessionTimeoutMinutes=30, roundTripTimeNanos=8130708}
23-12-23 04:45:35.043 I: Starting...
23-12-23 04:45:35.043 T: GameplayManager: Initializing BazaarService...
23-12-23 04:45:35.043 T: GameplayManager: Initializing CombatManager...
23-12-23 04:45:35.043 T: CombatManager: Initializing BuffService...
```