### PR TITLE
quest.task.ground.retrieve_item

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/objects/radial/RadialHandler.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/radial/RadialHandler.java
@@ -1,3 +1,29 @@
+/***********************************************************************************
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
 package com.projectswg.holocore.resources.support.objects.radial;
 
 import com.projectswg.common.data.objects.GameObjectType;
@@ -74,8 +100,8 @@ public enum RadialHandler {
 	}
 	
 	private void getHandler(SWGObject target, Consumer<RadialHandlerInterface> fn) {
-		String type = target.getTemplate();
-		RadialHandlerInterface handler = handlers.get(type);
+		String iff = target.getTemplate();
+		RadialHandlerInterface handler = handlers.get(iff);
 		if (handler != null)
 			fn.accept(handler);
 		

--- a/src/main/java/com/projectswg/holocore/services/gameplay/player/quest/MemoryRetrievedItemRepository.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/player/quest/MemoryRetrievedItemRepository.kt
@@ -24,35 +24,32 @@
  * You should have received a copy of the GNU Affero General Public License        *
  * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
  ***********************************************************************************/
+package com.projectswg.holocore.services.gameplay.player.quest
 
-@file:Suppress("NOTHING_TO_INLINE")
-package com.projectswg.holocore.intents.gameplay.player.quest
-
-import com.projectswg.holocore.resources.support.data.server_info.loader.QuestLoader.QuestTaskInfo
-import com.projectswg.holocore.resources.support.global.player.Player
 import com.projectswg.holocore.resources.support.objects.swg.SWGObject
-import me.joshlarson.jlcommon.control.Intent
+import com.projectswg.holocore.resources.support.objects.swg.player.PlayerObject
 
-data class GrantQuestIntent(val player: Player, val questName: String): Intent() {
-	companion object {
-		@JvmStatic inline fun broadcast(player: Player, questName: String) = GrantQuestIntent(player, questName).broadcast()
+/**
+ * Stores previously retrieved items in memory. This is not persistent across server restarts.
+ */
+class MemoryRetrievedItemRepository : RetrievedItemRepository {
+
+	private val retrievedItemMap = mutableMapOf<PlayerObject, MutableMap<String, MutableCollection<SWGObject>>>()
+
+	override fun addRetrieveAttempt(questName: String, playerObject: PlayerObject, retrievedItem: SWGObject) {
+		val questToItems = retrievedItemMap.computeIfAbsent(playerObject) { mutableMapOf() }
+		val items = questToItems.computeIfAbsent(questName) { mutableSetOf() }
+		items.add(retrievedItem)
 	}
-}
 
-data class AbandonQuestIntent(val player: Player, val questName: String): Intent() {
-	companion object {
-		@JvmStatic inline fun broadcast(player: Player, questName: String) = AbandonQuestIntent(player, questName).broadcast()
+	override fun hasAttemptedPreviously(questName: String, playerObject: PlayerObject, retrievedItem: SWGObject): Boolean {
+		val questToItems = retrievedItemMap[playerObject] ?: return false
+		val items = questToItems[questName] ?: return false
+		return items.contains(retrievedItem)
 	}
-}
 
-data class CompleteQuestIntent(val player: Player, val questName: String): Intent() {
-	companion object {
-		@JvmStatic inline fun broadcast(player: Player, questName: String) = CompleteQuestIntent(player, questName).broadcast()
-	}
-}
-
-data class QuestRetrieveItemIntent(val player: Player, val questName: String, val task: QuestTaskInfo, val item: SWGObject): Intent() {
-	companion object {
-		@JvmStatic inline fun broadcast(player: Player, questName: String, task: QuestTaskInfo, item: SWGObject) = QuestRetrieveItemIntent(player, questName, task, item).broadcast()
+	override fun clearPreviousAttempts(questName: String, playerObject: PlayerObject) {
+		val questToItems = retrievedItemMap[playerObject] ?: return
+		questToItems.remove(questName)
 	}
 }

--- a/src/main/java/com/projectswg/holocore/services/gameplay/player/quest/RetrievedItemRepository.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/player/quest/RetrievedItemRepository.kt
@@ -24,35 +24,16 @@
  * You should have received a copy of the GNU Affero General Public License        *
  * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
  ***********************************************************************************/
+package com.projectswg.holocore.services.gameplay.player.quest
 
-@file:Suppress("NOTHING_TO_INLINE")
-package com.projectswg.holocore.intents.gameplay.player.quest
-
-import com.projectswg.holocore.resources.support.data.server_info.loader.QuestLoader.QuestTaskInfo
-import com.projectswg.holocore.resources.support.global.player.Player
 import com.projectswg.holocore.resources.support.objects.swg.SWGObject
-import me.joshlarson.jlcommon.control.Intent
+import com.projectswg.holocore.resources.support.objects.swg.player.PlayerObject
 
-data class GrantQuestIntent(val player: Player, val questName: String): Intent() {
-	companion object {
-		@JvmStatic inline fun broadcast(player: Player, questName: String) = GrantQuestIntent(player, questName).broadcast()
-	}
-}
-
-data class AbandonQuestIntent(val player: Player, val questName: String): Intent() {
-	companion object {
-		@JvmStatic inline fun broadcast(player: Player, questName: String) = AbandonQuestIntent(player, questName).broadcast()
-	}
-}
-
-data class CompleteQuestIntent(val player: Player, val questName: String): Intent() {
-	companion object {
-		@JvmStatic inline fun broadcast(player: Player, questName: String) = CompleteQuestIntent(player, questName).broadcast()
-	}
-}
-
-data class QuestRetrieveItemIntent(val player: Player, val questName: String, val task: QuestTaskInfo, val item: SWGObject): Intent() {
-	companion object {
-		@JvmStatic inline fun broadcast(player: Player, questName: String, task: QuestTaskInfo, item: SWGObject) = QuestRetrieveItemIntent(player, questName, task, item).broadcast()
-	}
+/**
+ * Object store for retrieved items.
+ */
+interface RetrievedItemRepository {
+	fun addRetrieveAttempt(questName: String, playerObject: PlayerObject, retrievedItem: SWGObject)
+	fun hasAttemptedPreviously(questName: String, playerObject: PlayerObject, retrievedItem: SWGObject): Boolean
+	fun clearPreviousAttempts(questName: String, playerObject: PlayerObject)
 }


### PR DESCRIPTION
Relates to #1398.

Contains a refactor of `QuestLoader`. The class was horrible to work in with the amount of code lines needed to load just 1 column.
It's a little better now, but I have a TODO on converting it to Kotlin and continuing with the refactor effort.
I was facing annoying problems with the behavior where all columns were being loaded for all types of tasks. Most of the time, all columns don't have (meaningful) data in them and that made the parsing logic explode very often. It's more robust now for a couple of task types, but more task types need to be converted to this approach in the near future.