### PR TITLE
Fixed issue where quests with multiple active tasks at once would complete prematurely

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/gameplay/player/quest/QuestService.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/player/quest/QuestService.kt
@@ -379,7 +379,9 @@ class QuestService(private val destroyMultiAndLootDie: Die = RandomDie()) : Serv
 
 		if (nextTasksIdsOnComplete.isEmpty()) {
 			if (questLoader.getQuestListInfo(questName).isCompleteWhenTasksComplete) {
-				completeQuest(player, questName)
+				if (playerObject.getQuestActiveTasks(questName).isEmpty()) {
+					completeQuest(player, questName)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #1493

Basically, the code was checking if more tasks were coming.
It didn't account for existing tasks possibly not being complete yet.
