### PR TITLE
Fixed short "Hard Wrap" for Kotlin and Java in the Code Style

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -27,7 +27,6 @@
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="JAVA">
-      <option name="RIGHT_MARGIN" value="150" />
       <option name="KEEP_LINE_BREAKS" value="false" />
       <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
@@ -201,7 +200,6 @@
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
-      <option name="RIGHT_MARGIN" value="150" />
       <option name="KEEP_LINE_BREAKS" value="false" />
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
       <option name="METHOD_PARAMETERS_WRAP" value="0" />


### PR DESCRIPTION
I've been noticing that lines were being wrapped pretty aggressively. You can actaully see an example of it at line 178-180 below.
I recently enabled visual "helper lines" in IDEA for whitespaces and method separation, which made the problem very obvious.

Before this change:
![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/cf04d16c-ce76-4623-9edd-16d8ff08c5a0)

After this change, where the wrapping point is so far away that it can't be seen:
![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/03498a6b-24b8-4806-bf2a-375f225e17f0)
