### PR TITLE
Tweaked the default inspection profile so that it shows a "weak warning" whenever the Code Style isn't being followed

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="IncorrectFormatting" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+  </profile>
+</component>


### PR DESCRIPTION
The idea is to make formatting errors easier to find - like using spaces instead of tabs.
This is the specific setting I tweaked in the inspections profile:

![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/ca7bf19e-cd76-41fb-93b8-f90631959807)

Example in the IDE:

![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/4c6f1dab-d062-4845-aa27-e957bb35e867)

After applying the suggested 'Fix':

![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/f9fef036-15c5-47d1-81d8-48e643ab8e71)

Without this change, the same block of code shows no visual warnings to the developer:

![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/b04a8c5e-c3a5-4909-af48-90d3b1fef840)
