### PR TITLE
Fixed draft schematic persistence problem, where a server reboot woul…

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/objects/swg/player/PlayerObjectOwnerNP.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/swg/player/PlayerObjectOwnerNP.kt
@@ -163,7 +163,7 @@ internal class PlayerObjectOwnerNP(private val obj: PlayerObject) : MongoPersist
 		bb.addInt(maxMeds) // 15
 		bb.addObject(groupWaypoints) // 16
 		bb.addInt(jediState) // 17
-		bb.incrementOperandCount(19)
+		bb.incrementOperandCount(18)
 	}
 
 	fun parseBaseline9(buffer: NetBuffer) {
@@ -223,6 +223,7 @@ internal class PlayerObjectOwnerNP(private val obj: PlayerObject) : MongoPersist
 		craftingStage = data.getInteger("craftingStage", craftingStage)
 		nearbyCraftStation = data.getLong("nearbyCraftStation", nearbyCraftStation)
 		draftSchematics.putAll(data.getMap("draftSchematics", Long::class.java, Int::class.java))
+		draftSchematics.resetUpdateCount()	// If we don't do this, the client will display 0 draft schematics after a server reboot for all players
 		craftingComponentBioLink = data.getLong("craftingComponentBioLink", craftingComponentBioLink)
 		experimentPoints = data.getInteger("experimentPoints", experimentPoints)
 		expModified = data.getInteger("expModified", expModified)


### PR DESCRIPTION
…d cause the client to not display any draft schematics

Cherry-picked from #1341. When receiving draft schematics and persisting them in MongoDB, loading them back up from MongoDB would cause the `SWGMap` to have an invalid updateCount. This was enough to trigger the client to just not display any draft schematics.

Obviously we're not handing out draft schematics yet, so this isn't fixing a current problem, but it will fix a future one.