### PR TITLE
When generating a name for a given Race, don't bother checking if the…

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/data/namegen/SWGNameGenerator.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/namegen/SWGNameGenerator.java
@@ -1,5 +1,5 @@
 /***********************************************************************************
- * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
  * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
@@ -51,8 +51,6 @@ public class SWGNameGenerator {
 	
 	@NotNull
 	public String generateRaceName(@NotNull Race race) {
-		if (!nameFilter.isLoaded())
-			nameFilter.load();
 		return generateName("race_" + race.getSpecies());
 	}
 	


### PR DESCRIPTION
… nameFilter is loaded twice

The same check was present in both generateRaceName and generateName.