### PR TITLE
Automatically create PRs for updating pswgcommon to the latest version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+      day: "saturday"
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    allow:
+      - dependency-name: "pswgcommon"
+    schedule:
       interval: "weekly"
       day: "saturday"


### PR DESCRIPTION
Sometimes trivial changes are made in pswgcommon, such as: ProjectSWGCore/pswgcommon@4dfa51e7f479eba4b48e1058e3326ca078f3d8aa

Due to it being trivial, I didn't bother with creating a PR for the updated version in holocore.
It's a bit bad, because the next time changes are made in pswgcommon, they may not be trivial.
In that case, the PR now contains the complex changes *and* old, trivial ones.

Assuming this is merged, we should see a PR created by Dependabot to update the pswgcommon git submodule to the revision mentioned above.