### PR TITLE
Hand out the newbie quest to newly created characters

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/gameplay/newbie/NewbieService.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/newbie/NewbieService.kt
@@ -24,18 +24,45 @@
  * You should have received a copy of the GNU Affero General Public License        *
  * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
  ***********************************************************************************/
-package com.projectswg.holocore.services.gameplay.player
+package com.projectswg.holocore.services.gameplay.newbie
 
-import com.projectswg.holocore.services.gameplay.newbie.NewbieService
-import com.projectswg.holocore.services.gameplay.player.badge.BadgeManager
-import com.projectswg.holocore.services.gameplay.player.character.PlayerCharacterSheetService
-import com.projectswg.holocore.services.gameplay.player.character.TippingService
-import com.projectswg.holocore.services.gameplay.player.experience.ExperienceManager
-import com.projectswg.holocore.services.gameplay.player.group.GroupManager
-import com.projectswg.holocore.services.gameplay.player.guild.GuildService
-import com.projectswg.holocore.services.gameplay.player.quest.QuestService
-import me.joshlarson.jlcommon.control.Manager
-import me.joshlarson.jlcommon.control.ManagerStructure
+import com.projectswg.holocore.intents.gameplay.player.quest.GrantQuestIntent
+import com.projectswg.holocore.intents.support.global.zone.PlayerEventIntent
+import com.projectswg.holocore.intents.support.global.zone.creation.CreatedCharacterIntent
+import com.projectswg.holocore.resources.support.data.server_info.StandardLog
+import com.projectswg.holocore.resources.support.global.player.PlayerEvent
+import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject
+import me.joshlarson.jlcommon.control.IntentHandler
+import me.joshlarson.jlcommon.control.Service
 
-@ManagerStructure(children = [BadgeManager::class, ExperienceManager::class, GroupManager::class, GuildService::class, NewbieService::class, QuestService::class, PlayerCharacterSheetService::class, TippingService::class])
-class PlayerManager : Manager()
+/**
+ * Responsible for welcoming created characters to the game by handing out relevant quests.
+ */
+class NewbieService : Service() {
+
+	private val recentlyCreatedCharacters = mutableSetOf<CreatureObject>()
+
+	@IntentHandler
+	private fun handleCreatedCharacterIntent(intent: CreatedCharacterIntent) {
+		recentlyCreatedCharacters.add(intent.creatureObject)
+	}
+
+	@IntentHandler
+	private fun handlePlayerEventIntent(intent: PlayerEventIntent) {
+		if (intent.event != PlayerEvent.PE_ZONE_IN_SERVER) {
+			return
+		}
+
+		val creatureObject = intent.player.creatureObject
+
+		if (creatureObject !in recentlyCreatedCharacters) {
+			StandardLog.onPlayerTrace(this, creatureObject, "character not created recently, skipping newbie quest grant")
+			return
+		}
+
+		val player = intent.player
+		GrantQuestIntent.broadcast(player, "quest/c_newbie_start")
+
+		recentlyCreatedCharacters.remove(creatureObject)
+	}
+}


### PR DESCRIPTION
I had to get a bit creative with the two intent handlers.

At the time `CreatedCharacterIntent` is emitted, the owner of the `CreatureObject` is `null`, because the client hasn't requested zone-in yet.

And when the character is being zoned in, we don't have access the character creation context.

For that reason, the `recentlyCreatedCharacters` field contains some short-lived state, as the client triggers the zone-in flow right after character creation.

![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/df972cad-eebb-4279-9b4c-1a21d8a13cfc)
![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/099fee93-014e-46e9-aa94-a1eeacd52af2)
![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/109a71bf-aa64-4a99-9ee3-f8a6501dec49)