### PR TITLE
Mark Player as @NotNull in PlayerEventIntent to communicate null chec…

### DIFF
--- a/src/main/java/com/projectswg/holocore/intents/support/global/zone/PlayerEventIntent.java
+++ b/src/main/java/com/projectswg/holocore/intents/support/global/zone/PlayerEventIntent.java
@@ -1,5 +1,5 @@
 /***********************************************************************************
- * Copyright (c) 2018 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
  * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
@@ -29,18 +29,19 @@ package com.projectswg.holocore.intents.support.global.zone;
 import com.projectswg.holocore.resources.support.global.player.Player;
 import com.projectswg.holocore.resources.support.global.player.PlayerEvent;
 import me.joshlarson.jlcommon.control.Intent;
+import org.jetbrains.annotations.NotNull;
 
 public class PlayerEventIntent extends Intent {
 	
 	private Player player;
 	private PlayerEvent event;
 	
-	public PlayerEventIntent(Player p, PlayerEvent event) {
+	public PlayerEventIntent(@NotNull Player p, PlayerEvent event) {
 		setPlayer(p);
 		setEvent(event);
 	}
 	
-	public void setPlayer(Player p) {
+	public void setPlayer(@NotNull Player p) {
 		this.player = p;
 	}
 	
@@ -48,6 +49,7 @@ public class PlayerEventIntent extends Intent {
 		this.event = event;
 	}
 	
+	@NotNull
 	public Player getPlayer() {
 		return player;
 	}


### PR DESCRIPTION
…ks being unnecessary

While developing #1535, I had to ask my self: "Can `PlayerEventIntent` ever contain a `null` `Player`?"

The answer was no, so I figured I'd help ourselves in the future by just annotating the method.