### PR TITLE
SUI message box tasks in quest should only progress when the window i…

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/gameplay/player/quest/QuestService.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/player/quest/QuestService.kt
@@ -372,10 +372,11 @@ class QuestService(private val destroyMultiAndLootDie: Die = RandomDie(), privat
 		val messageBoxTitle = currentTask.messageBoxTitle
 		val messageBoxText = currentTask.messageBoxText
 		val sui = SuiMessageBox(SuiButtons.OK, messageBoxTitle, messageBoxText)
+		sui.addOkButtonCallback("questMessageBoxCallback") { _, _ -> completeTask(questName, player, currentTask) }
+		sui.addCancelButtonCallback("questMessageBoxCallback") { _, _ -> completeTask(questName, player, currentTask) }
 		sui.setSize(384, 256)
 		sui.setLocation(320, 256)
 		sui.display(player)
-		completeTask(questName, player, currentTask)
 	}
 
 	private fun handleCommPlayer(player: Player, questName: String, currentTask: QuestTaskInfo) {


### PR DESCRIPTION
…s closed, not when it's opened

It's especially obvious with quests that want to display multiple message boxes in succession, because you'll be reading the messages in the wrong order.
The newer windows lay on top of the older windows.