### PR TITLE
Added missing system message when completing a quest

### DIFF
--- a/src/main/java/com/projectswg/holocore/intents/gameplay/player/quest/QuestIntents.kt
+++ b/src/main/java/com/projectswg/holocore/intents/gameplay/player/quest/QuestIntents.kt
@@ -26,6 +26,7 @@
  ***********************************************************************************/
 package com.projectswg.holocore.intents.gameplay.player.quest
 
+import com.projectswg.holocore.resources.support.data.server_info.loader.QuestLoader
 import com.projectswg.holocore.resources.support.data.server_info.loader.QuestLoader.QuestTaskInfo
 import com.projectswg.holocore.resources.support.global.player.Player
 import com.projectswg.holocore.resources.support.objects.swg.SWGObject
@@ -34,5 +35,5 @@ import me.joshlarson.jlcommon.control.Intent
 data class GrantQuestIntent(val player: Player, val questName: String) : Intent()
 data class AbandonQuestIntent(val player: Player, val questName: String) : Intent()
 data class CompleteQuestIntent(val player: Player, val questName: String) : Intent()
-data class QuestRetrieveItemIntent(val player: Player, val questName: String, val task: QuestTaskInfo, val item: SWGObject) : Intent()
+data class QuestRetrieveItemIntent(val player: Player, val questListInfo: QuestLoader.QuestListInfo, val task: QuestTaskInfo, val item: SWGObject) : Intent()
 data class EmitQuestSignalIntent(val player: Player, val signalName: String) : Intent()

--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/QuestLoader.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/QuestLoader.kt
@@ -37,8 +37,8 @@ class QuestLoader : DataLoader() {
 	private val questListInfoMap: MutableMap<String, QuestListInfo> = Collections.synchronizedMap(HashMap())
 	private val questTaskInfosMap: MutableMap<String, List<QuestTaskInfo>> = Collections.synchronizedMap(HashMap())
 
-	val questNames: Collection<String>
-		get() = questListInfoMap.keys
+	val questListInfos: Collection<QuestListInfo>
+		get() = questListInfoMap.values
 
 	fun getQuestListInfo(questName: String): QuestListInfo? {
 		return questListInfoMap[questName]
@@ -82,15 +82,17 @@ class QuestLoader : DataLoader() {
 	private fun loadQuestListInfos() {
 		SdbLoader.load(File("serverdata/quests/questlist/questlist.msdb")).use { set ->
 			while (set.next()) {
-				val questName = set.getText("quest_name")
+				val questListInfo = QuestListInfo(set)
+				val questName = questListInfo.questName
 				if (questListInfoMap.containsKey(questName)) throw SdbLoaderException(set, RuntimeException("Duplicate quest list info for quest by name $questName"))
 
-				questListInfoMap[questName] = QuestListInfo(set)
+				questListInfoMap[questName] = questListInfo
 			}
 		}
 	}
 
 	class QuestListInfo(set: SdbResultSet) {
+		val questName: String = set.getText("quest_name")
 		val journalEntryTitle: String = set.getText("journal_entry_title")
 		val journalEntryDescription: String = set.getText("journal_entry_description")
 		val category: String = set.getText("category")

--- a/src/main/java/com/projectswg/holocore/services/gameplay/player/quest/QuestRetrieveItemRadialHandler.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/player/quest/QuestRetrieveItemRadialHandler.kt
@@ -29,22 +29,23 @@ package com.projectswg.holocore.services.gameplay.player.quest
 import com.projectswg.common.data.radial.RadialItem
 import com.projectswg.common.data.radial.RadialOption
 import com.projectswg.holocore.intents.gameplay.player.quest.QuestRetrieveItemIntent
+import com.projectswg.holocore.resources.support.data.server_info.loader.QuestLoader
 import com.projectswg.holocore.resources.support.data.server_info.loader.QuestLoader.QuestTaskInfo
 import com.projectswg.holocore.resources.support.global.player.Player
 import com.projectswg.holocore.resources.support.objects.radial.RadialHandlerInterface
 import com.projectswg.holocore.resources.support.objects.swg.SWGObject
 
-class QuestRetrieveItemRadialHandler(private val retrievedItemRepository: RetrievedItemRepository, private val questName: String, private val task: QuestTaskInfo) : RadialHandlerInterface {
+class QuestRetrieveItemRadialHandler(private val retrievedItemRepository: RetrievedItemRepository, private val questListInfo: QuestLoader.QuestListInfo, private val task: QuestTaskInfo) : RadialHandlerInterface {
 	private val radialItem = RadialItem.SERVER_MENU1
 	private val retriveItemInfo = task.retrieveItemInfo!!  // Precondition for this class
 
 	override fun getOptions(options: MutableCollection<RadialOption>, player: Player, target: SWGObject) {
 		val playerObject = player.playerObject
-		val questActiveTasks = playerObject.getQuestActiveTasks(questName)
+		val questActiveTasks = playerObject.getQuestActiveTasks(questListInfo.questName)
 		
 		if (questActiveTasks.contains(task.index)) {
 			if (target.template.equals(retriveItemInfo.serverTemplate)) {
-				if (!retrievedItemRepository.hasAttemptedPreviously(questName, playerObject, target)) {
+				if (!retrievedItemRepository.hasAttemptedPreviously(questListInfo.questName, playerObject, target)) {
 					options.add(RadialOption.create(radialItem, retriveItemInfo.retrieveMenuText))
 				}
 			}
@@ -55,6 +56,6 @@ class QuestRetrieveItemRadialHandler(private val retrievedItemRepository: Retrie
 		if (selection != radialItem)
 			return
 		
-		QuestRetrieveItemIntent(player, questName, task, target).broadcast()
+		QuestRetrieveItemIntent(player, questListInfo, task, target).broadcast()
 	}
 }


### PR DESCRIPTION
This required a bigger refactor than I had anticipated, honestly.
Problem was that I needed access to `QuestListInfo#category` way down in `completeQuest`, but all I had was a string `questName`. I do think this improves the code by introducing some type safety, though.

In-game now, using the test quest "quest/test_grant_quest_complete" bundled with SWG:
![image](https://github.com/ProjectSWGCore/Holocore/assets/4640241/c80d788f-338e-4b74-878b-e21940afe98d)

From an original screenshot:
![Snapshot - 2024-09-6-09-43-49](https://github.com/ProjectSWGCore/Holocore/assets/4640241/53c05c46-822b-4d7c-acf4-814087146717)
