### PR TITLE
Persist wounds, so a server reboot won't reset them

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/objects/swg/creature/CreatureObject.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/swg/creature/CreatureObject.java
@@ -1001,6 +1001,18 @@ public class CreatureObject extends TangibleObject {
 	public int getHealthWounds() {
 		return creo3.getHealthWounds();
 	}
+
+	/**
+	 * Using this method is not recommended. Use {@link CreatureObject#getHealthWounds()} instead.
+	 * <p> 
+	 * The indexes of the wounds are as follows:
+	 * 0: Health
+	 * 
+	 * @return a list of wounds
+	 */
+	public List<Integer> getWounds() {
+		return creo3.getWounds();
+	}
 	
 	@Override
 	public void createBaseline4(Player target, BaselineBuilder bb) {
@@ -1055,7 +1067,7 @@ public class CreatureObject extends TangibleObject {
 		super.readMongo(data);
 		skills.clear();
 
-		creo3.readMongo(data);
+		creo3.readMongo(data.getDocument("base3"));
 		creo4.readMongo(data.getDocument("base4"));
 		creo6.readMongo(data.getDocument("base6"));
 		race = Race.valueOf(data.getString("race", race.name()));

--- a/src/test/java/com/projectswg/holocore/resources/support/objects/swg/TestSWGPersistence.java
+++ b/src/test/java/com/projectswg/holocore/resources/support/objects/swg/TestSWGPersistence.java
@@ -159,7 +159,8 @@ public class TestSWGPersistence {
 						"battleFatigue", obj.getBattleFatigue(),
 						"ownerId", obj.getOwnerId(),
 						"statesBitmask", obj.getStatesBitmask(),
-						"factionRank", (int) obj.getFactionRank()
+						"factionRank", (int) obj.getFactionRank(),
+						"wounds", obj.getWounds()
 				),
 				"base4", map(
 						"accelPercent", obj.getAccelPercent(),


### PR DESCRIPTION
* Server loads up fine with existing characters, thanks to `MongoData#getArray` returning an empty list.
* I removed some old DB migration code regarding base3 that has served its purpose.
* I introduced some new DB migration code to ensure old creatures have a valid initial state regarding wounds.