### PR TITLE
Automated tests for tells

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/support/global/chat/ChatInstantMessageService.java
+++ b/src/main/java/com/projectswg/holocore/services/support/global/chat/ChatInstantMessageService.java
@@ -27,7 +27,6 @@
 package com.projectswg.holocore.services.support.global.chat;
 
 import com.projectswg.common.data.encodables.chat.ChatResult;
-import com.projectswg.common.network.packets.PacketType;
 import com.projectswg.common.network.packets.SWGPacket;
 import com.projectswg.common.network.packets.swg.zone.chat.ChatInstantMessageToCharacter;
 import com.projectswg.common.network.packets.swg.zone.chat.ChatInstantMessageToClient;
@@ -40,7 +39,6 @@ import me.joshlarson.jlcommon.control.IntentHandler;
 import me.joshlarson.jlcommon.control.Service;
 
 import java.util.Locale;
-import java.util.Objects;
 
 public class ChatInstantMessageService extends Service {
 	
@@ -51,10 +49,8 @@ public class ChatInstantMessageService extends Service {
 	@IntentHandler
 	private void handleInboundPacketIntent(InboundPacketIntent gpi) {
 		SWGPacket packet = gpi.getPacket();
-		if (Objects.requireNonNull(packet.getPacketType()) == PacketType.CHAT_INSTANT_MESSAGE_TO_CHARACTER) {
-			if (packet instanceof ChatInstantMessageToCharacter)
-				handleInstantMessage(gpi.getPlayer(), (ChatInstantMessageToCharacter) packet);
-		}
+		if (packet instanceof ChatInstantMessageToCharacter)
+			handleInstantMessage(gpi.getPlayer(), (ChatInstantMessageToCharacter) packet);
 	}
 	
 	private void handleInstantMessage(Player sender, ChatInstantMessageToCharacter request) {

--- a/src/test/java/com/projectswg/holocore/headless/CharacterSelectionScreen.kt
+++ b/src/test/java/com/projectswg/holocore/headless/CharacterSelectionScreen.kt
@@ -74,7 +74,7 @@ class CharacterSelectionScreen internal constructor(val player: GenericPlayer) {
 	fun selectCharacter(characterId: Long): ZonedInCharacter {
 		sendPacket(player, SelectCharacter(characterId))
 		sendPacket(player, ClientIdMsg())
-		player.waitForNextPacket(ClientPermissionsMessage::class.java, 50, TimeUnit.MILLISECONDS) ?: throw IllegalStateException("Failed to receive client permissions message in time")
+		player.waitForNextPacket(ClientPermissionsMessage::class.java) ?: throw IllegalStateException("Failed to receive client permissions message in time")
 		sendPacket(player, CmdSceneReady())
 
 		return ZonedInCharacter(player)

--- a/src/test/java/com/projectswg/holocore/headless/ignorelist.kt
+++ b/src/test/java/com/projectswg/holocore/headless/ignorelist.kt
@@ -1,0 +1,38 @@
+/***********************************************************************************
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.headless
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Adds a player to the ignore list.
+ * @param characterName the player to ignore
+ */
+fun ZonedInCharacter.addIgnore(characterName: String) {
+	sendCommand("addIgnore", null, characterName)
+	player.waitForNextObjectDelta(player.playerObject.objectId, 9, 8, 1, TimeUnit.SECONDS) ?: throw IllegalStateException("Packet not received")
+}

--- a/src/test/java/com/projectswg/holocore/headless/tells.kt
+++ b/src/test/java/com/projectswg/holocore/headless/tells.kt
@@ -1,0 +1,59 @@
+/***********************************************************************************
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.headless
+
+import com.projectswg.common.data.encodables.chat.ChatResult
+import com.projectswg.common.network.packets.swg.zone.chat.ChatInstantMessageToCharacter
+import com.projectswg.common.network.packets.swg.zone.chat.ChatInstantMessageToClient
+import com.projectswg.common.network.packets.swg.zone.chat.ChatOnSendInstantMessage
+import kotlin.random.Random
+
+/**
+ * Sends a tell to another player.
+ * @param characterName the player to send the tell to
+ * @param message the message to send
+ * @return the result of sending the tell
+ */
+fun ZonedInCharacter.sendTell(characterName: String, message: String): ChatResult {
+	val sequence = Random.nextInt()
+	sendPacket(player, ChatInstantMessageToCharacter("Testcase", characterName, message, sequence))
+	val chatOnSendInstantMessage = player.waitForNextPacket(ChatOnSendInstantMessage::class.java) ?: throw IllegalStateException("No tell receipt received")
+	if (chatOnSendInstantMessage.sequence != sequence) throw IllegalStateException("Invalid sequence. Expected $sequence, got ${chatOnSendInstantMessage.sequence}")
+	return ChatResult.fromInteger(chatOnSendInstantMessage.result)
+}
+
+/**
+ * Waits for a tell to be received. This method will block until a tell is received.
+ * @return the tell that was received
+ * @throws IllegalStateException if no tell is received
+ */
+fun ZonedInCharacter.waitForTell(): ReceivedTell {
+	val chatInstantMessageToClient = player.waitForNextPacket(ChatInstantMessageToClient::class.java) ?: throw IllegalStateException("No tell received")
+	return ReceivedTell(chatInstantMessageToClient.character, chatInstantMessageToClient.message)
+}
+
+data class ReceivedTell(val sender: String, val message: String)

--- a/src/test/java/com/projectswg/holocore/services/support/global/chat/TellTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/support/global/chat/TellTest.kt
@@ -28,6 +28,7 @@ package com.projectswg.holocore.services.support.global.chat
 
 import com.projectswg.common.data.encodables.chat.ChatResult
 import com.projectswg.holocore.headless.HeadlessSWGClient
+import com.projectswg.holocore.headless.addIgnore
 import com.projectswg.holocore.headless.sendTell
 import com.projectswg.holocore.headless.waitForTell
 import com.projectswg.holocore.resources.support.global.player.AccessLevel
@@ -81,10 +82,22 @@ class TellTest : AcceptanceTest() {
 	@Test
 	fun `drop tells to non-existent characters`() {
 		addUser("username", "password", AccessLevel.DEV)
+		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "charone")
+
+		val chatResult = character.sendTell("chartwo", "Hello")
+
+		assertEquals(ChatResult.TARGET_AVATAR_DOESNT_EXIST, chatResult)
+	}
+
+	@Test
+	fun `drop tells from ignored characters`() {
+		addUser("username", "password", AccessLevel.DEV)
 		val character1 = HeadlessSWGClient.createZonedInCharacter("username", "password", "charone")
+		val character2 = HeadlessSWGClient.createZonedInCharacter("username", "password", "chartwo")
+		character2.addIgnore("charone")
 
 		val chatResult = character1.sendTell("chartwo", "Hello")
 
-		assertEquals(ChatResult.TARGET_AVATAR_DOESNT_EXIST, chatResult)
+		assertEquals(ChatResult.IGNORED, chatResult)
 	}
 }

--- a/src/test/java/com/projectswg/holocore/services/support/global/chat/TellTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/support/global/chat/TellTest.kt
@@ -1,0 +1,90 @@
+/***********************************************************************************
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.services.support.global.chat
+
+import com.projectswg.common.data.encodables.chat.ChatResult
+import com.projectswg.holocore.headless.HeadlessSWGClient
+import com.projectswg.holocore.headless.sendTell
+import com.projectswg.holocore.headless.waitForTell
+import com.projectswg.holocore.resources.support.global.player.AccessLevel
+import com.projectswg.holocore.test.runners.AcceptanceTest
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class TellTest : AcceptanceTest() {
+
+	@Test
+	fun `tell is received by player`() {
+		addUser("username", "password", AccessLevel.DEV)
+		val character1 = HeadlessSWGClient.createZonedInCharacter("username", "password", "Charone")
+		val character2 = HeadlessSWGClient.createZonedInCharacter("username", "password", "Chartwo")
+
+		val chatResult = character1.sendTell("Chartwo", "Hello")
+		assertEquals(ChatResult.SUCCESS, chatResult)
+
+		val tell = character2.waitForTell()
+		assertAll(
+			{ assertEquals("Charone", tell.sender) },
+			{ assertEquals("Hello", tell.message) },
+		)
+	}
+
+	@Test
+	fun `receiving character name is case insensitive`() {
+		addUser("username", "password", AccessLevel.DEV)
+		val character1 = HeadlessSWGClient.createZonedInCharacter("username", "password", "Charone")
+		HeadlessSWGClient.createZonedInCharacter("username", "password", "Chartwo")
+
+		val chatResult = character1.sendTell("CHARTWO", "Hello")
+
+		assertEquals(ChatResult.SUCCESS, chatResult)
+	}
+
+	@Test
+	fun `tells can only be sent to online players`() {
+		addUser("username", "password", AccessLevel.DEV)
+		val character1 = HeadlessSWGClient.createZonedInCharacter("username", "password", "Charone")
+		val swgClient = HeadlessSWGClient("username")
+		val characterSelectionScreen = swgClient.login("password")
+		characterSelectionScreen.createCharacter("Chartwo")    // Create character but don't zone in
+
+		val chatResult = character1.sendTell("Chartwo", "Hello")
+
+		assertEquals(ChatResult.TARGET_AVATAR_DOESNT_EXIST, chatResult)
+	}
+
+	@Test
+	fun `drop tells to non-existent characters`() {
+		addUser("username", "password", AccessLevel.DEV)
+		val character1 = HeadlessSWGClient.createZonedInCharacter("username", "password", "charone")
+
+		val chatResult = character1.sendTell("chartwo", "Hello")
+
+		assertEquals(ChatResult.TARGET_AVATAR_DOESNT_EXIST, chatResult)
+	}
+}

--- a/src/test/java/com/projectswg/holocore/test/runners/AcceptanceTest.kt
+++ b/src/test/java/com/projectswg/holocore/test/runners/AcceptanceTest.kt
@@ -46,6 +46,7 @@ import com.projectswg.holocore.services.gameplay.player.character.TippingService
 import com.projectswg.holocore.services.gameplay.player.experience.ExperiencePointService
 import com.projectswg.holocore.services.gameplay.player.experience.skills.SkillService
 import com.projectswg.holocore.services.gameplay.player.group.GroupService
+import com.projectswg.holocore.services.support.global.chat.ChatInstantMessageService
 import com.projectswg.holocore.services.support.global.chat.ChatMailService
 import com.projectswg.holocore.services.support.global.chat.ChatSystemService
 import com.projectswg.holocore.services.support.global.commands.CommandExecutionService
@@ -94,6 +95,7 @@ abstract class AcceptanceTest : TestRunnerSynchronousIntents() {
 		registerService(SkillService())
 		registerService(ChatSystemService())
 		registerService(ChatMailService())
+		registerService(ChatInstantMessageService())
 		registerService(SuiService())
 		registerService(RadialService())
 		registerService(TippingService())

--- a/src/test/java/com/projectswg/holocore/test/runners/AcceptanceTest.kt
+++ b/src/test/java/com/projectswg/holocore/test/runners/AcceptanceTest.kt
@@ -46,6 +46,7 @@ import com.projectswg.holocore.services.gameplay.player.character.TippingService
 import com.projectswg.holocore.services.gameplay.player.experience.ExperiencePointService
 import com.projectswg.holocore.services.gameplay.player.experience.skills.SkillService
 import com.projectswg.holocore.services.gameplay.player.group.GroupService
+import com.projectswg.holocore.services.support.global.chat.ChatFriendService
 import com.projectswg.holocore.services.support.global.chat.ChatInstantMessageService
 import com.projectswg.holocore.services.support.global.chat.ChatMailService
 import com.projectswg.holocore.services.support.global.chat.ChatSystemService
@@ -96,6 +97,7 @@ abstract class AcceptanceTest : TestRunnerSynchronousIntents() {
 		registerService(ChatSystemService())
 		registerService(ChatMailService())
 		registerService(ChatInstantMessageService())
+		registerService(ChatFriendService())
 		registerService(SuiService())
 		registerService(RadialService())
 		registerService(TippingService())


### PR DESCRIPTION
This covers all behaviors that I've been able to find regarding tells. With this, we can safely rewrite the whole subsystem - a conversion to Kotlin, for example.

# The edit to the production code
The packets that the testing DSL "send" don't have the `packetType` field inside set. That field is only set when deserializing the packet in the networking code. There's no other way to set them.
I edited `ChatInstantMessageService` a bit for that reason, as `Objects.requireNonNull(packet.getPacketType()) == PacketType.CHAT_INSTANT_MESSAGE_TO_CHARACTER` always evaluated to `false`.

Perhaps something can be done regarding the statefulness of `SWGPacket` - that's a problem for another day, though.
An idea that sprung to mind was simply setting the fields inside the packet constructors - a `ChatInstantMessageToCharacter` packet with the `PacketType` and/or `crc` of completely different packet makes little sense, so why make it possible.