### PR TITLE
Generate random credentials instead of defining them, so there's less…

### DIFF
--- a/src/test/java/com/projectswg/holocore/resources/support/global/zone/creation/CharacterCreationTest.kt
+++ b/src/test/java/com/projectswg/holocore/resources/support/global/zone/creation/CharacterCreationTest.kt
@@ -1,3 +1,29 @@
+/***********************************************************************************
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create an emulator which will provide a server for players to    *
+ * continue playing a game similar to the one they used to play. We are basing     *
+ * it on the final publish of the game prior to end-game events.                   *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
 package com.projectswg.holocore.resources.support.global.zone.creation
 
 import com.projectswg.holocore.headless.HeadlessSWGClient
@@ -6,26 +32,22 @@ import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureOb
 import com.projectswg.holocore.test.runners.AcceptanceTest
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class CharacterCreationTest : AcceptanceTest() {
 
-	@BeforeEach
-	fun setUpUser() {
-		addUser("username", "password")
-	}
-
 	@Test
 	fun `new characters receive a Slitherhorn`() {
-		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
+		val user = generateUser()
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
 
 		assertTrue(inventoryContainsSlitherhorn(character.player.creatureObject))
 	}
 
 	@Test
 	fun `new characters become Novice in all basic professions`() {
-		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
+		val user = generateUser()
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
 
 		val skills = character.player.creatureObject.skills
 		assertAll(
@@ -40,7 +62,8 @@ class CharacterCreationTest : AcceptanceTest() {
 
 	@Test
 	fun `new characters receive their species skill`() {
-		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
+		val user = generateUser()
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
 
 		assertTrue(character.player.creatureObject.skills.contains("species_human"))
 	}

--- a/src/test/java/com/projectswg/holocore/services/gameplay/combat/HealthWoundTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/combat/HealthWoundTest.kt
@@ -29,19 +29,14 @@ package com.projectswg.holocore.services.gameplay.combat
 import com.projectswg.holocore.headless.*
 import com.projectswg.holocore.test.runners.AcceptanceTest
 import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class HealthWoundTest : AcceptanceTest() {
 
-	@BeforeEach
-	fun setUpUser() {
-		addUser("username", "password")
-	}
-
 	@Test
 	fun `weapons with Wound Chance apply health wounds`() {
-		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
+		val user = generateUser()
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
 		character.player.creatureObject.equippedWeapon.woundChance = 100F
 		val npc = spawnNPC("creature_bantha", character.player.creatureObject.location, combatLevelRange = 80..80)
 
@@ -52,7 +47,8 @@ class HealthWoundTest : AcceptanceTest() {
 
 	@Test
 	fun `only weapons with Wound Chance apply health wounds`() {
-		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
+		val user = generateUser()
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
 		character.player.creatureObject.equippedWeapon.woundChance = 0F
 		val npc = spawnNPC("creature_bantha", character.player.creatureObject.location, combatLevelRange = 80..80)
 
@@ -63,7 +59,8 @@ class HealthWoundTest : AcceptanceTest() {
 
 	@Test
 	fun `health wounds are subtracted from current health`() {
-		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
+		val user = generateUser()
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
 		val npc = spawnNPC("creature_bantha", character.player.creatureObject.location, combatLevelRange = 80..80)
 		npc.healthWounds = npc.health - 1    // The NPC should effectively have 1 health left this way
 

--- a/src/test/java/com/projectswg/holocore/services/gameplay/combat/loot/LootTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/combat/loot/LootTest.kt
@@ -1,5 +1,5 @@
 /***********************************************************************************
- * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
  * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
@@ -37,8 +37,8 @@ class LootTest : AcceptanceTest() {
 	
 	@Test
 	fun itemsAreGenerated() {
-		addUser("player", "pass")
-		val zonedInCharacter = createZonedInCharacter("player", "pass", "tester")
+		val user = generateUser()
+		val zonedInCharacter = createZonedInCharacter(user.username, user.password, "tester")
 		val npc = spawnNPC("creature_kreetle_swarmling", zonedInCharacter.player.creatureObject.location)
 		npc.health = 1
 		zonedInCharacter.attack(npc)

--- a/src/test/java/com/projectswg/holocore/services/gameplay/player/TipCreditsTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/player/TipCreditsTest.kt
@@ -1,5 +1,5 @@
 /***********************************************************************************
- * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
  * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
@@ -37,8 +37,8 @@ class TipCreditsTest : AcceptanceTest() {
 
 	@Test
 	fun negativeAmount() {
-		val zonedInCharacter1 = createZonedInCharacter("Playerone", "Charone")
-		val zonedInCharacter2 = createZonedInCharacter("Playertwo", "Chartwo")
+		val zonedInCharacter1 = createZonedInCharacter("Charone")
+		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
 		val tipAmount = -50
 
 		assertThrows(TipException::class.java) {
@@ -48,8 +48,8 @@ class TipCreditsTest : AcceptanceTest() {
 
 	@Test
 	fun notEnoughMoneyForSurcharge() {
-		val zonedInCharacter1 = createZonedInCharacter("Playerone", "Charone")
-		val zonedInCharacter2 = createZonedInCharacter("Playertwo", "Chartwo")
+		val zonedInCharacter1 = createZonedInCharacter("Charone")
+		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
 		val tipAmount = zonedInCharacter1.player.creatureObject.bankBalance	// Sending all bank balance should never be possible, because of the 5% surcharge
 
 		assertThrows(TipException::class.java) {
@@ -59,7 +59,7 @@ class TipCreditsTest : AcceptanceTest() {
 
 	@Test
 	fun npc() {
-		val zonedInCharacter1 = createZonedInCharacter("Playerone", "Charone")
+		val zonedInCharacter1 = createZonedInCharacter("Charone")
 		val womprat = spawnNPC("creature_womprat", zonedInCharacter1.player.creatureObject.location)
 		
 		assertThrows(TipException::class.java) {
@@ -69,7 +69,7 @@ class TipCreditsTest : AcceptanceTest() {
 
 	@Test
 	fun self() {
-		val zonedInCharacter1 = createZonedInCharacter("Playerone", "Charone")
+		val zonedInCharacter1 = createZonedInCharacter("Charone")
 		
 		assertThrows(TipException::class.java) {
 			zonedInCharacter1.tip(zonedInCharacter1.player.creatureObject, 1)
@@ -78,8 +78,8 @@ class TipCreditsTest : AcceptanceTest() {
 	
 	@Test
 	fun sufficientCash() {
-		val zonedInCharacter1 = createZonedInCharacter("Playerone", "Charone")
-		val zonedInCharacter2 = createZonedInCharacter("Playertwo", "Chartwo")
+		val zonedInCharacter1 = createZonedInCharacter("Charone")
+		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
 		val char1Before = CreditsSnapshot(zonedInCharacter1)
 		val char2Before = CreditsSnapshot(zonedInCharacter2)
 		val tipAmount = 1
@@ -96,8 +96,8 @@ class TipCreditsTest : AcceptanceTest() {
 
 	@Test
 	fun sufficientBank() {
-		val zonedInCharacter1 = createZonedInCharacter("Playerone", "Charone")
-		val zonedInCharacter2 = createZonedInCharacter("Playertwo", "Chartwo")
+		val zonedInCharacter1 = createZonedInCharacter("Charone")
+		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
 		val char1Before = CreditsSnapshot(zonedInCharacter1)
 		val char2Before = CreditsSnapshot(zonedInCharacter2)
 		val tipAmount = 100
@@ -117,8 +117,8 @@ class TipCreditsTest : AcceptanceTest() {
 
 	@Test
 	fun tooFarAway() {
-		val zonedInCharacter1 = createZonedInCharacter("Playerone", "Charone")
-		val zonedInCharacter2 = createZonedInCharacter("Playertwo", "Chartwo")
+		val zonedInCharacter1 = createZonedInCharacter("Charone")
+		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
 		zonedInCharacter2.adminTeleport(
 			planet = zonedInCharacter1.player.creatureObject.terrain,
 			x = zonedInCharacter1.player.creatureObject.x + 20,
@@ -133,8 +133,8 @@ class TipCreditsTest : AcceptanceTest() {
 
 	@Test
 	fun differentPlanet() {
-		val zonedInCharacter1 = createZonedInCharacter("Playerone", "Charone")
-		val zonedInCharacter2 = createZonedInCharacter("Playertwo", "Chartwo")
+		val zonedInCharacter1 = createZonedInCharacter("Charone")
+		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
 		zonedInCharacter2.adminTeleport(	// Same coordinates, but different planet
 			planet = Terrain.DANTOOINE,
 			x = zonedInCharacter1.player.creatureObject.x,
@@ -149,8 +149,8 @@ class TipCreditsTest : AcceptanceTest() {
 
 	@Test
 	fun insufficientBank() {
-		val zonedInCharacter1 = createZonedInCharacter("Playerone", "Charone")
-		val zonedInCharacter2 = createZonedInCharacter("Playertwo", "Chartwo")
+		val zonedInCharacter1 = createZonedInCharacter("Charone")
+		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
 		val char1Before = CreditsSnapshot(zonedInCharacter1)
 		val tipAmount = char1Before.bank * 2
 
@@ -159,10 +159,9 @@ class TipCreditsTest : AcceptanceTest() {
 		}
 	}
 
-	private fun createZonedInCharacter(username: String, characterName: String): ZonedInCharacter {
-		val password = "password"
-		addUser(username, password, accessLevel = AccessLevel.DEV)
-		return HeadlessSWGClient.createZonedInCharacter(username, password, characterName)
+	private fun createZonedInCharacter(characterName: String): ZonedInCharacter {
+		val user = generateUser(accessLevel = AccessLevel.DEV)
+		return HeadlessSWGClient.createZonedInCharacter(user.username, user.password, characterName)
 	}
 
 }

--- a/src/test/java/com/projectswg/holocore/services/gameplay/player/badge/ExplorationBadgeTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/player/badge/ExplorationBadgeTest.kt
@@ -1,5 +1,5 @@
 /***********************************************************************************
- * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
  * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
@@ -38,8 +38,8 @@ import org.junit.jupiter.api.Test
 class ExplorationBadgeTest : AcceptanceTest() {
 	@Test
 	fun enteringAreaGrantsBadge() {
-		addUser("Test", "Test", AccessLevel.DEV)
-		val character = HeadlessSWGClient.createZonedInCharacter("Test", "Test", "char")
+		val user = generateUser(accessLevel = AccessLevel.DEV)
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "char")
 
 		character.adminTeleport(planet = Terrain.MUSTAFAR, x = 0, y = 0, z = 0)
 

--- a/src/test/java/com/projectswg/holocore/services/gameplay/player/experience/AdminCommandAccessTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/player/experience/AdminCommandAccessTest.kt
@@ -1,5 +1,5 @@
 /***********************************************************************************
- * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
  * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
@@ -39,16 +39,16 @@ class AdminCommandAccessTest : AcceptanceTest() {
 
 	@Test
 	fun adminsCanUseAdminCommands() {
-		addUser("admin", "password", accessLevel = AccessLevel.DEV)
-		val character = HeadlessSWGClient.createZonedInCharacter("admin", "password", "adminchar")
+		val user = generateUser(accessLevel = AccessLevel.DEV)
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
 
 		assertDoesNotThrow { character.adminGrantSkill("outdoors_scout_master") }
 	}
 
 	@Test
 	fun onlyAdminsCanUseAdminCommands() {
-		addUser("player", "password", accessLevel = AccessLevel.PLAYER)
-		val character = HeadlessSWGClient.createZonedInCharacter("player", "password", "playerchar")
+		val user = generateUser(accessLevel = AccessLevel.PLAYER)
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "playerchar")
 
 		assertThrows<CommandFailedException> {
 			character.adminGrantSkill("outdoors_scout_master")

--- a/src/test/java/com/projectswg/holocore/services/gameplay/player/experience/SkillTreeTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/player/experience/SkillTreeTest.kt
@@ -1,5 +1,5 @@
 /***********************************************************************************
- * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
  * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
@@ -32,19 +32,14 @@ import com.projectswg.holocore.headless.surrenderSkill
 import com.projectswg.holocore.resources.support.global.player.AccessLevel
 import com.projectswg.holocore.test.runners.AcceptanceTest
 import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class SkillTreeTest : AcceptanceTest() {
 
-	@BeforeEach
-	fun setUp() {
-		addUser("username", "password", accessLevel = AccessLevel.DEV)
-	}
-
 	@Test
 	fun surrenderSkill() {
-		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
+		val user = generateUser()
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
 
 		character.surrenderSkill("outdoors_scout_novice")	// Every character has this skill by default
 
@@ -53,7 +48,8 @@ class SkillTreeTest : AcceptanceTest() {
 
 	@Test
 	fun grantPrerequisiteSkills() {
-		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
+		val user = generateUser(accessLevel = AccessLevel.DEV)
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
 
 		character.adminGrantSkill("outdoors_scout_master")
 
@@ -62,7 +58,8 @@ class SkillTreeTest : AcceptanceTest() {
 
 	@Test
 	fun socialProfessionsDoNotIncreaseCombatLevel() {
-		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
+		val user = generateUser(accessLevel = AccessLevel.DEV)
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
 		val combatLevel = character.player.creatureObject.level
 
 		character.adminGrantSkill("social_entertainer_master")
@@ -72,7 +69,8 @@ class SkillTreeTest : AcceptanceTest() {
 
 	@Test
 	fun combatProfessionsIncreaseCombatLevel() {
-		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
+		val user = generateUser(accessLevel = AccessLevel.DEV)
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
 		val combatLevel = character.player.creatureObject.level
 
 		character.adminGrantSkill("combat_marksman_master")

--- a/src/test/java/com/projectswg/holocore/services/gameplay/player/group/GroupTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/player/group/GroupTest.kt
@@ -1,5 +1,5 @@
 /***********************************************************************************
- * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
  * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
@@ -35,8 +35,8 @@ class GroupTest : AcceptanceTest() {
 
 	@Test
 	fun formGroup() {
-		val zonedInCharacter1 = createZonedInCharacter("Playerone", "Charone")
-		val zonedInCharacter2 = createZonedInCharacter("Playertwo", "Chartwo")
+		val zonedInCharacter1 = createZonedInCharacter("Charone")
+		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
 
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter2)
 		zonedInCharacter2.acceptCurrentGroupInvitation()
@@ -46,8 +46,8 @@ class GroupTest : AcceptanceTest() {
 
 	@Test
 	fun makeLeader() {
-		val zonedInCharacter1 = createZonedInCharacter("Playerone", "Charone")
-		val zonedInCharacter2 = createZonedInCharacter("Playertwo", "Chartwo")
+		val zonedInCharacter1 = createZonedInCharacter("Charone")
+		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter2)
 		zonedInCharacter2.acceptCurrentGroupInvitation()
 
@@ -61,8 +61,8 @@ class GroupTest : AcceptanceTest() {
 
 	@Test
 	fun makeLeaderOnlyWorksForCurrentLeader() {
-		val zonedInCharacter1 = createZonedInCharacter("Playerone", "Charone")
-		val zonedInCharacter2 = createZonedInCharacter("Playertwo", "Chartwo")
+		val zonedInCharacter1 = createZonedInCharacter("Charone")
+		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter2)
 		zonedInCharacter2.acceptCurrentGroupInvitation()
 
@@ -76,9 +76,9 @@ class GroupTest : AcceptanceTest() {
 
 	@Test
 	fun memberLeavesGroup() {
-		val zonedInCharacter1 = createZonedInCharacter("Playerone", "Charone")
-		val zonedInCharacter2 = createZonedInCharacter("Playertwo", "Chartwo")
-		val zonedInCharacter3 = createZonedInCharacter("Playerthree", "Charthree")
+		val zonedInCharacter1 = createZonedInCharacter("Charone")
+		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
+		val zonedInCharacter3 = createZonedInCharacter("Charthree")
 
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter2)
 		zonedInCharacter2.acceptCurrentGroupInvitation()
@@ -96,9 +96,9 @@ class GroupTest : AcceptanceTest() {
 
 	@Test
 	fun leaderKicksMember() {
-		val zonedInCharacter1 = createZonedInCharacter("Playerone", "Charone")
-		val zonedInCharacter2 = createZonedInCharacter("Playertwo", "Chartwo")
-		val zonedInCharacter3 = createZonedInCharacter("Playerthree", "Charthree")
+		val zonedInCharacter1 = createZonedInCharacter("Charone")
+		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
+		val zonedInCharacter3 = createZonedInCharacter("Charthree")
 
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter2)
 		zonedInCharacter2.acceptCurrentGroupInvitation()
@@ -116,9 +116,9 @@ class GroupTest : AcceptanceTest() {
 
 	@Test
 	fun leaderLeavesGroup() {
-		val zonedInCharacter1 = createZonedInCharacter("Playerone", "Charone")
-		val zonedInCharacter2 = createZonedInCharacter("Playertwo", "Chartwo")
-		val zonedInCharacter3 = createZonedInCharacter("Playerthree", "Charthree")
+		val zonedInCharacter1 = createZonedInCharacter("Charone")
+		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
+		val zonedInCharacter3 = createZonedInCharacter("Charthree")
 
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter2)
 		zonedInCharacter2.acceptCurrentGroupInvitation()
@@ -134,10 +134,9 @@ class GroupTest : AcceptanceTest() {
 		)
 	}
 
-	private fun createZonedInCharacter(username: String, characterName: String): ZonedInCharacter {
-		val password = "password"
-		addUser(username, password)
-		return HeadlessSWGClient.createZonedInCharacter(username, password, characterName)
+	private fun createZonedInCharacter(characterName: String): ZonedInCharacter {
+		val user = generateUser()
+		return HeadlessSWGClient.createZonedInCharacter(user.username, user.password, characterName)
 	}
 
 }

--- a/src/test/java/com/projectswg/holocore/services/support/CharacterManagementTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/support/CharacterManagementTest.kt
@@ -1,5 +1,5 @@
 /***********************************************************************************
- * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
  * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
@@ -37,9 +37,9 @@ class CharacterManagementTest : AcceptanceTest() {
 
 	@Test
 	fun deleteCharacter() {
-		addUser("username", "password")
-		val headlessSWGClient = HeadlessSWGClient("username")
-		val characterSelectionScreen = headlessSWGClient.login("password")
+		val user = generateUser()
+		val headlessSWGClient = HeadlessSWGClient(user.username)
+		val characterSelectionScreen = headlessSWGClient.login(user.password)
 		val characterId = characterSelectionScreen.createCharacter("firstcharacter")
 
 		characterSelectionScreen.deleteCharacter(characterId)
@@ -49,9 +49,9 @@ class CharacterManagementTest : AcceptanceTest() {
 
 	@Test
 	fun characterCreationRateLimit() {
-		addUser("username", "password")
-		val headlessSWGClient = HeadlessSWGClient("username")
-		val characterSelectionScreen = headlessSWGClient.login("password")
+		val user = generateUser()
+		val headlessSWGClient = HeadlessSWGClient(user.username)
+		val characterSelectionScreen = headlessSWGClient.login(user.password)
 		characterSelectionScreen.createCharacter("firstcharacter")
 		characterSelectionScreen.createCharacter("secondcharacter")
 

--- a/src/test/java/com/projectswg/holocore/services/support/KillAdminCommandTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/support/KillAdminCommandTest.kt
@@ -1,5 +1,5 @@
 /***********************************************************************************
- * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
  * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
@@ -39,8 +39,8 @@ class KillAdminCommandTest : AcceptanceTest() {
 
 	@Test
 	fun killNpc() {
-		addUser("username", "password", AccessLevel.DEV)
-		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
+		val user = generateUser(AccessLevel.DEV)
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
 		val npc = spawnNPC("creature_bantha", character.player.creatureObject.location, NpcStaticSpawnLoader.SpawnerFlag.ATTACKABLE)
 
 		character.adminKill(npc)
@@ -50,8 +50,8 @@ class KillAdminCommandTest : AcceptanceTest() {
 
 	@Test
 	fun killInvulnerableNpc() {
-		addUser("username", "password", AccessLevel.DEV)
-		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
+		val user = generateUser(AccessLevel.DEV)
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
 		val npc = spawnNPC("creature_bantha", character.player.creatureObject.location, NpcStaticSpawnLoader.SpawnerFlag.INVULNERABLE)
 
 		character.adminKill(npc)
@@ -64,8 +64,8 @@ class KillAdminCommandTest : AcceptanceTest() {
 
 	@Test
 	fun killSelf() {
-		addUser("username", "password", AccessLevel.DEV)
-		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "adminchar")
+		val user = generateUser(AccessLevel.DEV)
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
 
 		character.adminKill(character.player.creatureObject)
 

--- a/src/test/java/com/projectswg/holocore/services/support/LoginTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/support/LoginTest.kt
@@ -1,5 +1,5 @@
 /***********************************************************************************
- * Copyright (c) 2023 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
  * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
@@ -39,44 +39,44 @@ class LoginTest : AcceptanceTest() {
 
 	@Test
 	fun validCredentials() {
-		addUser("username", "password")
-		val headlessSWGClient = HeadlessSWGClient("username")
+		val user = generateUser()
+		val headlessSWGClient = HeadlessSWGClient(user.username)
 
-		val characterSelectionScreen = headlessSWGClient.login("password")
+		val characterSelectionScreen = headlessSWGClient.login(user.password)
 
 		assertNotNull(characterSelectionScreen)
 	}
 
 	@Test
 	fun validCredentialsButBanned() {
-		addUser("username", "password", banned = true)
-		val headlessSWGClient = HeadlessSWGClient("username")
+		val user = generateUser(banned = true)
+		val headlessSWGClient = HeadlessSWGClient(user.username)
 
-		assertThrows<AccountBannedException> { headlessSWGClient.login("password") }
+		assertThrows<AccountBannedException> { headlessSWGClient.login(user.password) }
 	}
 
 	@Test
 	fun wrongUsername() {
-		addUser("username", "password")
+		val user = generateUser()
 		val headlessSWGClient = HeadlessSWGClient("wrongusername")
 
-		assertThrows<WrongCredentialsException> { headlessSWGClient.login("password") }
+		assertThrows<WrongCredentialsException> { headlessSWGClient.login(user.password) }
 	}
 
 	@Test
 	fun wrongPassword() {
-		addUser("username", "password")
-		val headlessSWGClient = HeadlessSWGClient("username")
+		val user = generateUser()
+		val headlessSWGClient = HeadlessSWGClient(user.username)
 
 		assertThrows<WrongCredentialsException> { headlessSWGClient.login("wrongpassword") }
 	}
 
 	@Test
 	fun wrongVersion() {
-		addUser("username", "password")
-		val headlessSWGClient = HeadlessSWGClient("username", "20030404-14:00")
+		val user = generateUser()
+		val headlessSWGClient = HeadlessSWGClient(user.username, "20030404-14:00")
 
-		assertThrows<WrongClientVersionException> { headlessSWGClient.login("password") }
+		assertThrows<WrongClientVersionException> { headlessSWGClient.login(user.password) }
 	}
 
 

--- a/src/test/java/com/projectswg/holocore/services/support/global/chat/TellTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/support/global/chat/TellTest.kt
@@ -31,7 +31,6 @@ import com.projectswg.holocore.headless.HeadlessSWGClient
 import com.projectswg.holocore.headless.addIgnore
 import com.projectswg.holocore.headless.sendTell
 import com.projectswg.holocore.headless.waitForTell
-import com.projectswg.holocore.resources.support.global.player.AccessLevel
 import com.projectswg.holocore.test.runners.AcceptanceTest
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -41,9 +40,9 @@ class TellTest : AcceptanceTest() {
 
 	@Test
 	fun `tell is received by player`() {
-		addUser("username", "password", AccessLevel.DEV)
-		val character1 = HeadlessSWGClient.createZonedInCharacter("username", "password", "Charone")
-		val character2 = HeadlessSWGClient.createZonedInCharacter("username", "password", "Chartwo")
+		val user = generateUser()
+		val character1 = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "Charone")
+		val character2 = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "Chartwo")
 
 		val chatResult = character1.sendTell("Chartwo", "Hello")
 		assertEquals(ChatResult.SUCCESS, chatResult)
@@ -57,9 +56,9 @@ class TellTest : AcceptanceTest() {
 
 	@Test
 	fun `receiving character name is case insensitive`() {
-		addUser("username", "password", AccessLevel.DEV)
-		val character1 = HeadlessSWGClient.createZonedInCharacter("username", "password", "Charone")
-		HeadlessSWGClient.createZonedInCharacter("username", "password", "Chartwo")
+		val user = generateUser()
+		val character1 = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "Charone")
+		HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "Chartwo")
 
 		val chatResult = character1.sendTell("CHARTWO", "Hello")
 
@@ -68,10 +67,10 @@ class TellTest : AcceptanceTest() {
 
 	@Test
 	fun `tells can only be sent to online players`() {
-		addUser("username", "password", AccessLevel.DEV)
-		val character1 = HeadlessSWGClient.createZonedInCharacter("username", "password", "Charone")
-		val swgClient = HeadlessSWGClient("username")
-		val characterSelectionScreen = swgClient.login("password")
+		val user = generateUser()
+		val character1 = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "Charone")
+		val swgClient = HeadlessSWGClient(user.username)
+		val characterSelectionScreen = swgClient.login(user.password)
 		characterSelectionScreen.createCharacter("Chartwo")    // Create character but don't zone in
 
 		val chatResult = character1.sendTell("Chartwo", "Hello")
@@ -81,8 +80,8 @@ class TellTest : AcceptanceTest() {
 
 	@Test
 	fun `drop tells to non-existent characters`() {
-		addUser("username", "password", AccessLevel.DEV)
-		val character = HeadlessSWGClient.createZonedInCharacter("username", "password", "charone")
+		val user = generateUser()
+		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "Charone")
 
 		val chatResult = character.sendTell("chartwo", "Hello")
 
@@ -91,9 +90,9 @@ class TellTest : AcceptanceTest() {
 
 	@Test
 	fun `drop tells from ignored characters`() {
-		addUser("username", "password", AccessLevel.DEV)
-		val character1 = HeadlessSWGClient.createZonedInCharacter("username", "password", "charone")
-		val character2 = HeadlessSWGClient.createZonedInCharacter("username", "password", "chartwo")
+		val user = generateUser()
+		val character1 = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "charone")
+		val character2 = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "chartwo")
 		character2.addIgnore("charone")
 
 		val chatResult = character1.sendTell("chartwo", "Hello")

--- a/src/test/java/com/projectswg/holocore/test/runners/AcceptanceTest.kt
+++ b/src/test/java/com/projectswg/holocore/test/runners/AcceptanceTest.kt
@@ -65,6 +65,7 @@ import com.projectswg.holocore.services.support.objects.radials.RadialService
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
+import java.util.*
 
 /**
  * Acceptance test runner that sets up all the services required for an acceptance test.
@@ -121,8 +122,14 @@ abstract class AcceptanceTest : TestRunnerSynchronousIntents() {
 		}
 	}
 
-	fun addUser(username: String, password: String, accessLevel: AccessLevel = AccessLevel.PLAYER, banned: Boolean = false) {
+	/**
+	 * Generates a user with a random username and password.
+	 */
+	fun generateUser(accessLevel: AccessLevel = AccessLevel.PLAYER, banned: Boolean = false): UserCredentials {
+		val username = UUID.randomUUID().toString().substringBefore("-")    // UUIDs are a bit long for usernames
+		val password = UUID.randomUUID().toString()
 		memoryUserDatabase.addUser(username, password, accessLevel, banned)
+		return UserCredentials(username, password)
 	}
 
 	/**

--- a/src/test/java/com/projectswg/holocore/test/runners/UserCredentials.kt
+++ b/src/test/java/com/projectswg/holocore/test/runners/UserCredentials.kt
@@ -24,58 +24,6 @@
  * You should have received a copy of the GNU Affero General Public License        *
  * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
  ***********************************************************************************/
-package com.projectswg.holocore.services.gameplay.player.experience
+package com.projectswg.holocore.test.runners
 
-import com.projectswg.holocore.headless.*
-import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject
-import com.projectswg.holocore.test.runners.AcceptanceTest
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
-
-class TrappingXPTest : AcceptanceTest() {
-
-	@Test
-	fun scoutsGetTrappingXPFromKillingCreatures() {
-		val user = generateUser()
-		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
-		val npc = spawnNPC("creature_bantha", character.player.creatureObject.location)
-
-		killTarget(character, npc)
-
-		assertTrue(character.player.playerObject.getExperiencePoints("trapping") > 0)
-	}
-
-	@Test
-	fun onlyScoutsGetTrappingXPFromKillingCreatures() {
-		val user = generateUser()
-		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
-		character.surrenderSkill("outdoors_scout_novice")
-		val npc = spawnNPC("creature_bantha", character.player.creatureObject.location)
-
-		killTarget(character, npc)
-
-		assertEquals(0, character.player.playerObject.getExperiencePoints("trapping"))
-	}
-
-	@Test
-	fun scoutsGetNoTrappingXPFromKillingNonCreatures() {
-		val user = generateUser()
-		val character = HeadlessSWGClient.createZonedInCharacter(user.username, user.password, "adminchar")
-		val npc = spawnNPC("humanoid_tusken_commoner", character.player.creatureObject.location)
-
-		killTarget(character, npc)
-
-		assertEquals(0, character.player.playerObject.getExperiencePoints("trapping"))
-	}
-
-	private fun killTarget(character: ZonedInCharacter, target: CreatureObject) {
-		target.health = 1
-		val targetState = character.attack(target)
-
-		if (targetState != TargetState.DEAD) {
-			throw IllegalStateException("Target is not dead, but is instead $targetState")
-		}
-	}
-
-}
+data class UserCredentials(val username: String, val password: String)


### PR DESCRIPTION
… setup noise in the test cases

I've been looking into reusing more setup across test cases, and an obvious initial problem is the reuse of account names.
This would cause problems with character creation, as a given username is only allowed to create two characters in a 15 minute sliding window.

That, and seeing less "username", "password" strings in the setup code is nice.