### PR TITLE
Combat engine now takes accuracy bonus from buffs into account

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandAttack.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/combat/command/CombatCommandAttack.kt
@@ -457,6 +457,8 @@ internal class CombatCommandAttack(private val toHitDie: Die, private val knockd
 				accMod += source.getSkillModValue(accuracySkillMod)
 			}
 
+			accMod += source.getSkillModValue("private_accuracy_bonus")
+
 			return accMod
 		}
 


### PR DESCRIPTION
Fixes #458
Fixes #851
Fixes #1130

Animations and action costs are already in place for Aim and the enhanced variants.
The missing piece was simply the skillmod applied by the buff not being used.