### PR TITLE
Headless client now waits for objects to spawn like a real client doe…

### DIFF
--- a/src/test/java/com/projectswg/holocore/headless/CharacterSelectionScreen.kt
+++ b/src/test/java/com/projectswg/holocore/headless/CharacterSelectionScreen.kt
@@ -1,11 +1,10 @@
 /***********************************************************************************
- * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2025 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
- * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * ProjectSWG is an emulation project for Star Wars Galaxies founded on            *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
- * Our goal is to create an emulator which will provide a server for players to    *
- * continue playing a game similar to the one they used to play. We are basing     *
- * it on the final publish of the game prior to end-game events.                   *
+ * Our goal is to create one or more emulators which will provide servers for      *
+ * players to continue playing a game similar to the one they used to play.        *
  *                                                                                 *
  * This file is part of Holocore.                                                  *
  *                                                                                 *
@@ -30,6 +29,7 @@ import com.projectswg.common.network.packets.swg.login.ClientIdMsg
 import com.projectswg.common.network.packets.swg.login.ClientPermissionsMessage
 import com.projectswg.common.network.packets.swg.login.creation.*
 import com.projectswg.common.network.packets.swg.zone.CmdSceneReady
+import com.projectswg.common.network.packets.swg.zone.SceneEndBaselines
 import com.projectswg.common.network.packets.swg.zone.insertion.SelectCharacter
 import com.projectswg.holocore.test.resources.GenericPlayer
 import java.lang.RuntimeException
@@ -75,6 +75,10 @@ class CharacterSelectionScreen internal constructor(val player: GenericPlayer) {
 		sendPacket(player, SelectCharacter(characterId))
 		sendPacket(player, ClientIdMsg())
 		player.waitForNextPacket(ClientPermissionsMessage::class.java) ?: throw IllegalStateException("Failed to receive client permissions message in time")
+		var waitForMoreObjects = true
+		while (waitForMoreObjects) {
+			waitForMoreObjects = player.waitForNextPacket(SceneEndBaselines::class.java, 50, TimeUnit.MILLISECONDS) != null
+		}
 		sendPacket(player, CmdSceneReady())
 		player.waitForNextPacket(CmdSceneReady::class.java) ?: throw IllegalStateException("Expected CmdSceneReady from server but did not receive it in time")
 

--- a/src/test/java/com/projectswg/holocore/headless/awareness.kt
+++ b/src/test/java/com/projectswg/holocore/headless/awareness.kt
@@ -1,0 +1,33 @@
+/***********************************************************************************
+ * Copyright (c) 2025 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is an emulation project for Star Wars Galaxies founded on            *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create one or more emulators which will provide servers for      *
+ * players to continue playing a game similar to the one they used to play.        *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.headless
+
+import com.projectswg.common.network.packets.swg.zone.SceneDestroyObject
+import java.util.concurrent.TimeUnit
+
+fun ZonedInCharacter.waitUntilObjectDestroyed(objectId: Long) {
+	player.waitForNextPacket(SceneDestroyObject::class.java, 1, TimeUnit.SECONDS) { it.objectId == objectId }
+}

--- a/src/test/java/com/projectswg/holocore/services/gameplay/player/TipCreditsTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/player/TipCreditsTest.kt
@@ -1,11 +1,10 @@
 /***********************************************************************************
- * Copyright (c) 2024 /// Project SWG /// www.projectswg.com                       *
+ * Copyright (c) 2025 /// Project SWG /// www.projectswg.com                       *
  *                                                                                 *
- * ProjectSWG is the first NGE emulator for Star Wars Galaxies founded on          *
+ * ProjectSWG is an emulation project for Star Wars Galaxies founded on            *
  * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
- * Our goal is to create an emulator which will provide a server for players to    *
- * continue playing a game similar to the one they used to play. We are basing     *
- * it on the final publish of the game prior to end-game events.                   *
+ * Our goal is to create one or more emulators which will provide servers for      *
+ * players to continue playing a game similar to the one they used to play.        *
  *                                                                                 *
  * This file is part of Holocore.                                                  *
  *                                                                                 *
@@ -125,6 +124,7 @@ class TipCreditsTest : AcceptanceTest() {
 			y = zonedInCharacter1.player.creatureObject.y,
 			z = zonedInCharacter1.player.creatureObject.z
 		)
+		zonedInCharacter1.waitUntilObjectDestroyed(zonedInCharacter2.player.creatureObject.objectId)
 
 		val suiWindow = zonedInCharacter1.tip(zonedInCharacter2.player.creatureObject, 100)
 
@@ -141,6 +141,7 @@ class TipCreditsTest : AcceptanceTest() {
 			y = zonedInCharacter1.player.creatureObject.y,
 			z = zonedInCharacter1.player.creatureObject.z
 		)
+		zonedInCharacter1.waitUntilObjectDestroyed(zonedInCharacter2.player.creatureObject.objectId)
 
 		val suiWindow = zonedInCharacter1.tip(zonedInCharacter2.player.creatureObject, 100)
 

--- a/src/test/java/com/projectswg/holocore/services/gameplay/player/group/GroupTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/player/group/GroupTest.kt
@@ -38,7 +38,7 @@ class GroupTest : AcceptanceTest() {
 		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
 
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter2)
-		zonedInCharacter2.acceptCurrentGroupInvitation()
+		zonedInCharacter2.acceptCurrentGroupInvitation(zonedInCharacter1)
 
 		assertTrue(zonedInCharacter1.isInGroupWith(zonedInCharacter2))
 	}
@@ -48,7 +48,7 @@ class GroupTest : AcceptanceTest() {
 		val zonedInCharacter1 = createZonedInCharacter("Charone")
 		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter2)
-		zonedInCharacter2.acceptCurrentGroupInvitation()
+		zonedInCharacter2.acceptCurrentGroupInvitation(zonedInCharacter1)
 
 		zonedInCharacter1.makeGroupLeader(zonedInCharacter2)
 
@@ -63,7 +63,7 @@ class GroupTest : AcceptanceTest() {
 		val zonedInCharacter1 = createZonedInCharacter("Charone")
 		val zonedInCharacter2 = createZonedInCharacter("Chartwo")
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter2)
-		zonedInCharacter2.acceptCurrentGroupInvitation()
+		zonedInCharacter2.acceptCurrentGroupInvitation(zonedInCharacter1)
 
 		zonedInCharacter2.makeGroupLeader(zonedInCharacter2)
 
@@ -80,9 +80,9 @@ class GroupTest : AcceptanceTest() {
 		val zonedInCharacter3 = createZonedInCharacter("Charthree")
 
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter2)
-		zonedInCharacter2.acceptCurrentGroupInvitation()
+		zonedInCharacter2.acceptCurrentGroupInvitation(zonedInCharacter1)
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter3)
-		zonedInCharacter3.acceptCurrentGroupInvitation()
+		zonedInCharacter3.acceptCurrentGroupInvitation(zonedInCharacter1)
 
 		zonedInCharacter2.leaveCurrentGroup()
 
@@ -100,9 +100,9 @@ class GroupTest : AcceptanceTest() {
 		val zonedInCharacter3 = createZonedInCharacter("Charthree")
 
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter2)
-		zonedInCharacter2.acceptCurrentGroupInvitation()
+		zonedInCharacter2.acceptCurrentGroupInvitation(zonedInCharacter1)
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter3)
-		zonedInCharacter3.acceptCurrentGroupInvitation()
+		zonedInCharacter3.acceptCurrentGroupInvitation(zonedInCharacter1)
 
 		zonedInCharacter1.kickFromGroup(zonedInCharacter2)
 
@@ -120,9 +120,9 @@ class GroupTest : AcceptanceTest() {
 		val zonedInCharacter3 = createZonedInCharacter("Charthree")
 
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter2)
-		zonedInCharacter2.acceptCurrentGroupInvitation()
+		zonedInCharacter2.acceptCurrentGroupInvitation(zonedInCharacter1)
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter3)
-		zonedInCharacter3.acceptCurrentGroupInvitation()
+		zonedInCharacter3.acceptCurrentGroupInvitation(zonedInCharacter1)
 
 		zonedInCharacter1.leaveCurrentGroup()
 
@@ -141,9 +141,9 @@ class GroupTest : AcceptanceTest() {
 		val characters = listOf(zonedInCharacter1, zonedInCharacter2, zonedInCharacter3)
 
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter2)
-		zonedInCharacter2.acceptCurrentGroupInvitation()
+		zonedInCharacter2.acceptCurrentGroupInvitation(zonedInCharacter1)
 		zonedInCharacter1.invitePlayerToGroup(zonedInCharacter3)
-		zonedInCharacter3.acceptCurrentGroupInvitation()
+		zonedInCharacter3.acceptCurrentGroupInvitation(zonedInCharacter1)
 
 		assertAll(
 			{ assertTrue(zonedInCharacter1.isInGroupWith(zonedInCharacter2)) },

--- a/src/test/java/com/projectswg/holocore/test/resources/GenericPlayer.java
+++ b/src/test/java/com/projectswg/holocore/test/resources/GenericPlayer.java
@@ -55,7 +55,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -177,7 +177,7 @@ public class GenericPlayer extends Player {
 	}
 	
 	@Nullable
-	public <T extends SWGPacket> T waitForNextPacket(Class<T> type, long timeout, TimeUnit unit, Function<T, Boolean> filter) {
+	public <T extends SWGPacket> T waitForNextPacket(Class<T> type, long timeout, TimeUnit unit, Predicate<T> filter) {
 		packetLock.lock();
 		try {
 			long startTime = System.nanoTime();
@@ -187,8 +187,7 @@ public class GenericPlayer extends Player {
 					if (type.isInstance(next)) {
 						it.remove();
 						T packet = type.cast(next);
-						Boolean match = filter.apply(packet);
-						if (match) {
+						if (filter.test(packet)) {
 							return packet;
 						}
 					}
@@ -207,7 +206,7 @@ public class GenericPlayer extends Player {
 	}
 	@Nullable
 	public DeltasMessage waitForNextObjectDelta(long objectId, int num, int update, long timeout, TimeUnit unit) {
-		Function<DeltasMessage, Boolean> deltaPacketFilter = p -> p.getObjectId() == objectId && p.getNum() == num && p.getUpdate() == update;
+		Predicate<DeltasMessage> deltaPacketFilter = p -> p.getObjectId() == objectId && p.getNum() == num && p.getUpdate() == update;
 		return waitForNextPacket(DeltasMessage.class, timeout, unit, deltaPacketFilter);
 	}
 


### PR DESCRIPTION
…s, before sending CmdSceneReady

This increases the robustness of awareness-based tests, as two characters created simultaneously were pretty much never aware of each other before the testing logic began.