### PR TITLE
Fixed buggy behaviors with healthPercent

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/gameplay/player/experience/skills/skillmod/HamSkillModService.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/player/experience/skills/skillmod/HamSkillModService.kt
@@ -48,10 +48,10 @@ class HamSkillModService : Service() {
 	private fun handleHealthPercent(intent: SkillModIntent, adjustModifier: Int) {
 		for (creature in intent.affectedCreatures) {
 			val originalMaxHealth = creature.maxHealth
-			val extraMaxHealth = ((adjustModifier / 100.0) * creature.maxHealth).toInt()    // If healthPercent is 10, then mod is 1.1. A creature with 1000 health will then have 1100 health.
-			creature.maxHealth += extraMaxHealth
-			
-			StandardLog.onPlayerTrace(this, creature, "max health increased by $adjustModifier%% $originalMaxHealth -> ${creature.maxHealth}")	// %% is used to escape the % character
+			val newMaxHealth = HealthPercentCalculator.calculateNewMaxHealth(originalMaxHealth, adjustModifier)
+			creature.maxHealth = newMaxHealth
+
+			StandardLog.onPlayerTrace(this, creature, "max health increased by $adjustModifier%% $originalMaxHealth -> $newMaxHealth")	// %% is used to escape the % character
 		}
 	}
 }

--- a/src/main/java/com/projectswg/holocore/services/gameplay/player/experience/skills/skillmod/HealthPercentCalculator.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/player/experience/skills/skillmod/HealthPercentCalculator.kt
@@ -25,53 +25,26 @@
  ***********************************************************************************/
 package com.projectswg.holocore.services.gameplay.player.experience.skills.skillmod
 
-import com.projectswg.holocore.intents.gameplay.player.experience.SkillModIntent
-import com.projectswg.holocore.intents.support.objects.ContainerTransferIntent
-import com.projectswg.holocore.resources.support.objects.swg.SWGObject
-import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject
-import com.projectswg.holocore.resources.support.objects.swg.tangible.TangibleObject
-import me.joshlarson.jlcommon.control.IntentHandler
-import me.joshlarson.jlcommon.control.Service
+import kotlin.math.abs
+import kotlin.math.round
 
-class SkillModService : Service() {
+object HealthPercentCalculator {
 
-	@IntentHandler
-	private fun handlehandleContainerTransferIntent(cti: ContainerTransferIntent) {
-		val owner = cti.obj.owner ?: return
-		val creature = owner.creatureObject
+	fun calculateNewMaxHealth(currentMaxHealth: Int, newHealthPercentMod: Int): Int {
+		val multiplier = calculateMultiplier(newHealthPercentMod)
+		val newMaxHealth = round(multiplier * currentMaxHealth).toInt()    // If healthPercent is 10, then mod is 1.1. A creature with 1000 health will then have 1100 health.
+		
+		return newMaxHealth
+	}
 
-		val obj = cti.obj
-		if (obj is TangibleObject) {
-			val skillMods: Map<String, Int> = obj.skillMods
-
-			for (skillMod in skillMods) {
-				val modName = skillMod.key
-				val modValue = skillMod.value
-
-				if (isEquippingItem(cti.container, creature)) {
-					SkillModIntent(modName, 0, modValue, creature).broadcast()
-				} else if (isUnequippingItem(cti.oldContainer, creature)) {
-					SkillModIntent(modName, 0, -modValue, creature).broadcast()
-				}
-			}
+	private fun calculateMultiplier(adjustModifier: Int): Double {
+		return if (adjustModifier < 0) {
+			removalMultiplier(adjustModifier)
+		} else {
+			additionMultiplier(adjustModifier)
 		}
 	}
-
-	private fun isEquippingItem(container: SWGObject?, creature: CreatureObject): Boolean {
-		return container != null && container.objectId == creature.objectId
-	}
-
-	private fun isUnequippingItem(oldContainer: SWGObject?, creature: CreatureObject): Boolean {
-		return oldContainer != null && oldContainer.objectId == creature.objectId
-	}
-
-	@IntentHandler
-	private fun handleSkillModIntent(smi: SkillModIntent) {
-		for (creature in smi.affectedCreatures) {
-			val skillModName = smi.skillModName
-			val adjustBase = smi.adjustBase
-			val adjustModifier = smi.adjustModifier
-			creature.adjustSkillmod(skillModName, adjustBase, adjustModifier)
-		}
-	}
+	
+	private fun removalMultiplier(percent: Int) = 1.0 / additionMultiplier(abs(percent))
+	private fun additionMultiplier(percent: Int) = 1.0 + percent / 100.0
 }

--- a/src/test/java/com/projectswg/holocore/services/gameplay/player/experience/skills/skillmod/HealthPercentCalculatorTest.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/player/experience/skills/skillmod/HealthPercentCalculatorTest.kt
@@ -25,53 +25,23 @@
  ***********************************************************************************/
 package com.projectswg.holocore.services.gameplay.player.experience.skills.skillmod
 
-import com.projectswg.holocore.intents.gameplay.player.experience.SkillModIntent
-import com.projectswg.holocore.intents.support.objects.ContainerTransferIntent
-import com.projectswg.holocore.resources.support.objects.swg.SWGObject
-import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject
-import com.projectswg.holocore.resources.support.objects.swg.tangible.TangibleObject
-import me.joshlarson.jlcommon.control.IntentHandler
-import me.joshlarson.jlcommon.control.Service
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 
-class SkillModService : Service() {
+class HealthPercentCalculatorTest {
 
-	@IntentHandler
-	private fun handlehandleContainerTransferIntent(cti: ContainerTransferIntent) {
-		val owner = cti.obj.owner ?: return
-		val creature = owner.creatureObject
-
-		val obj = cti.obj
-		if (obj is TangibleObject) {
-			val skillMods: Map<String, Int> = obj.skillMods
-
-			for (skillMod in skillMods) {
-				val modName = skillMod.key
-				val modValue = skillMod.value
-
-				if (isEquippingItem(cti.container, creature)) {
-					SkillModIntent(modName, 0, modValue, creature).broadcast()
-				} else if (isUnequippingItem(cti.oldContainer, creature)) {
-					SkillModIntent(modName, 0, -modValue, creature).broadcast()
-				}
-			}
-		}
+	@Test
+	fun testAdd() {
+		assertEquals(3300, HealthPercentCalculator.calculateNewMaxHealth(3000, 10))
 	}
 
-	private fun isEquippingItem(container: SWGObject?, creature: CreatureObject): Boolean {
-		return container != null && container.objectId == creature.objectId
-	}
+	@Test
+	fun testAddThenRemove() {
+		val originalMaxHealth = 2487
+		
+		val buffedMaxHealth = HealthPercentCalculator.calculateNewMaxHealth(originalMaxHealth, 10)
+		val unbuffedMaxHealth = HealthPercentCalculator.calculateNewMaxHealth(buffedMaxHealth, -10)
 
-	private fun isUnequippingItem(oldContainer: SWGObject?, creature: CreatureObject): Boolean {
-		return oldContainer != null && oldContainer.objectId == creature.objectId
-	}
-
-	@IntentHandler
-	private fun handleSkillModIntent(smi: SkillModIntent) {
-		for (creature in smi.affectedCreatures) {
-			val skillModName = smi.skillModName
-			val adjustBase = smi.adjustBase
-			val adjustModifier = smi.adjustModifier
-			creature.adjustSkillmod(skillModName, adjustBase, adjustModifier)
-		}
+		assertEquals(originalMaxHealth, unbuffedMaxHealth, "We should have the same health as we started with")
 	}
 }


### PR DESCRIPTION
As was discussed in Discord, for the most part.

I decided to move the handling of the skill mod inside `CreatureObject`. My reasons:

1. Potential race condition between `SkillModService` and `HamSkillModService`. `HamSkillModService` now needs to know how much healthPercent the `CreatureObject` already has, but this information may or may not have been altered in the meantime by `SkillModService`.
2. This way, the healthPercent mod will also work if you call `CreatureObject#adjustSkillmod` directly.

# Tests
1: Initial state, no buffs or anything

![image](https://github.com/user-attachments/assets/ea80bfb7-400a-416d-9cf6-fedee62fe151)

2: With Nutrient Injection (healthPercent +10%)

![image](https://github.com/user-attachments/assets/7004ccfa-24d9-4065-b609-699b9cc897a4)

3: Nutrient Injection expired

![image](https://github.com/user-attachments/assets/947c68bf-8a49-49be-8c11-f05e26ca646b)
