### PR TITLE
Fixed most vehicle customization variables not being applied

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/gameplay/world/travel/PlayerMountService.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/world/travel/PlayerMountService.kt
@@ -256,7 +256,6 @@ class PlayerMountService : Service() {
 		mount.setTurnScale(vehicleInfo.turnRateMax.toDouble())
 		mount.setAccelScale(vehicleInfo.accelMax)
 		mount.putCustomization("/private/index_speed_max", (vehicleInfo.speed * 10.0).toInt())
-		mount.putCustomization("/private/index_speed_min", (vehicleInfo.minSpeed * 10.0).toInt())
 		mount.putCustomization("/private/index_turn_rate_min", vehicleInfo.turnRate)
 		mount.putCustomization("/private/index_turn_rate_max", vehicleInfo.turnRateMax)
 		mount.putCustomization("/private/index_accel_min", (vehicleInfo.accelMin * 10.0).toInt())
@@ -269,7 +268,6 @@ class PlayerMountService : Service() {
 		mount.putCustomization("/private/index_banking", vehicleInfo.bankingAngle.toInt())
 		mount.putCustomization("/private/index_hover_height", (vehicleInfo.hoverHeight * 10.0).toInt())
 		mount.putCustomization("/private/index_auto_level", (vehicleInfo.autoLevel * 100.0).toInt())
-		mount.putCustomization("/private/index_strafe", if (vehicleInfo.isStrafe) 1 else 0)
 
 		ObjectCreatedIntent(mount).broadcast()
 		StandardLog.onPlayerTrace(this, player, "called mount %s at %s %s", mount, mount.terrain, mount.location.position)


### PR DESCRIPTION
Fixes #1289

Apparently the client completely stops applying customization variables after encountering ones that it doesn't recognize.
Simply removing the ones it doesn't know resolves the issue.

I figured out which to remove by having a look in customizatio/customization_id_manager.iff:

![image](https://github.com/user-attachments/assets/a347afc5-eee2-4ac9-baf8-f4fbeb9ed11a)

Works now:

![image](https://github.com/user-attachments/assets/99e01eab-723f-4fd4-94b1-fb470a8586f7)

It's worth noting that this has affected much more than jetpack hover height - only max speed was ever _actually_ being applied by the client. The jetpack hover height was just very obvious.