### PR TITLE
Fixed off-by-one in death cybernetic odds

### DIFF
--- a/src/main/java/com/projectswg/holocore/services/gameplay/combat/DeathCyberneticService.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/combat/DeathCyberneticService.kt
@@ -46,7 +46,7 @@ class DeathCyberneticService(private val deathCyberneticDie: Die = RandomDie()) 
 		if (isSpace(diedOnTerrain)) return
 		if (isEasyPlanet(diedOnTerrain)) return
 		if (isADeathCyberneticAlreadyInstalled(creature)) return
-		if (deathCyberneticDie.roll(1..100) < 5) installDeathCybernetic(creature)
+		if (deathCyberneticDie.roll(1..100) <= 5) installDeathCybernetic(creature)
 	}
 
 	private fun installDeathCybernetic(creature: CreatureObject) {
@@ -59,10 +59,10 @@ class DeathCyberneticService(private val deathCyberneticDie: Die = RandomDie()) 
 	}
 
 	private fun selectDeathCyberneticLimb(): String {
-		return if (deathCyberneticDie.roll(1..100) < 25) {
+		return if (deathCyberneticDie.roll(1..100) <= 25) {
 			"object/tangible/wearables/cybernetic/s01/cybernetic_s01_legs.iff"
 		} else {
-			if (deathCyberneticDie.roll(1..100) < 50) {
+			if (deathCyberneticDie.roll(1..100) <= 50) {
 				"object/tangible/wearables/cybernetic/s01/shared_cybernetic_s01_arm_r.iff"
 			} else {
 				"object/tangible/wearables/cybernetic/s01/shared_cybernetic_s01_arm_l.iff"


### PR DESCRIPTION
The thresholds were written for a 0..99 roll but the die rolls 1..100,
giving 4% instead of 5% install chance, 24% instead of 25% legs, and a
49/51 arm split instead of even.
