### PR TITLE
Persist vehicle condition damage on the control device

### DIFF
--- a/src/main/java/com/projectswg/holocore/resources/support/objects/swg/ServerAttribute.java
+++ b/src/main/java/com/projectswg/holocore/resources/support/objects/swg/ServerAttribute.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 
 public enum ServerAttribute {
 	PCD_PET_TEMPLATE	("pcd.pet.template",				PredefinedDataType.STRING),
+	PCD_PET_CONDITION_DAMAGE("pcd.pet.condition_damage",	PredefinedDataType.INT),
 	EGG_SPAWNER			("egg.spawner",						Spawner.class, s -> null, s -> null),
 	GALACTIC_RESOURCE_ID("resources.galactic_resource_id",	PredefinedDataType.LONG),
 	SURVEY_TOOL_RANGE	("survey_tool.range",				PredefinedDataType.INT),

--- a/src/main/java/com/projectswg/holocore/services/gameplay/world/travel/PlayerMountService.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/world/travel/PlayerMountService.kt
@@ -235,6 +235,7 @@ class PlayerMountService : Service() {
 		mount.addOptionFlags(OptionFlag.MOUNT) // The mount won't appear properly if this isn't set
 		mount.faction = player.faction
 		mount.ownerId = player.objectId // Client crash if this isn't set before making anyone aware
+		mount.conditionDamage = mountControlDevice.getServerAttribute(ServerAttribute.PCD_PET_CONDITION_DAMAGE) as Int? ?: 0
 
 		// TODO after combat there's a delay
 		// TODO update faction status on mount if necessary
@@ -396,6 +397,7 @@ class PlayerMountService : Service() {
 			vehicleDecayJobs[mount]?.cancel()
 
 			// Destroy the mount
+			mountControlDevice.setServerAttribute(ServerAttribute.PCD_PET_CONDITION_DAMAGE, mount.conditionDamage)
 			mountControlDevice.count = IntangibleObject.COUNT_PCD_STORED
 			player.broadcast(DestroyObjectIntent(mount))
 			StandardLog.onPlayerTrace(this, player, "stored mount %s at %s %s", mount, mount.terrain, mount.location.position)

--- a/src/test/java/com/projectswg/holocore/services/gameplay/world/travel/TestPlayerMountService.kt
+++ b/src/test/java/com/projectswg/holocore/services/gameplay/world/travel/TestPlayerMountService.kt
@@ -91,6 +91,22 @@ class TestPlayerMountService : TestRunnerSimulatedWorld() {
 	}
 	
 	@Test
+	fun testConditionSurvivesStoring() {
+		val creature: CreatureObject = createCreature()
+		ObjectCreatedIntent(creature).broadcast()
+		val deed = ObjectCreator.createObjectFromTemplate(getUniqueId(), DEED)
+		broadcastAndWait(VehicleDeedGenerateIntent(creature, deed))
+		updateAwareness()
+		val pcd = creature.findAware(PCD) as IntangibleObject
+		(creature.findAware(SWOOP) as CreatureObject).conditionDamage = 500
+		broadcastAndWait(PetDeviceStoreIntent(creature, pcd))
+		broadcastAndWait(PetDeviceCallIntent(creature, pcd))
+		updateAwareness()
+
+		Assertions.assertEquals(500, (creature.findAware(SWOOP) as CreatureObject).conditionDamage)
+	}
+
+	@Test
 	fun testMountDismount() {
 		val friend = createNPC()
 		friend.systemMove(null, Location.builder(friend.location).setPosition(110.0, 110.0, 110.0).build())


### PR DESCRIPTION
Fixes #1411

The damage is now saved on the PCD when storing and applied again when calling the mount.