### PR TITLE
Faction rank sdb

### DIFF
--- a/serverdata/faction/rank.sdb
+++ b/serverdata/faction/rank.sdb
@@ -1,0 +1,24 @@
+index	name	cost	delegate_ratio_from	delegate_ratio_to
+
+0	recruit	10	20	2
+1	private	10	20	3
+2	lance_corporal	400	20	4
+3	corporal	800	20	5
+4	staff_corporal	1200	20	6
+5	sergeant	1600	20	7
+6	staff_sergeant	2000	20	8
+7	master_sergeant	2500	20	9
+8	warrant_officer_2	3000	20	10
+9	warrant_officer_1	3500	20	11
+10	second_lieutenant	4000	20	12
+11	lieutenant	5000	20	13
+12	captain	5000	20	14
+13	major	5500	20	15
+14	lieutenant_colonel	5500	20	16
+15	colonel	6000	20	17
+16	brigadier_general	6500	20	18
+17	major_general	6500	20	18
+18	lieutenant_general	7000	20	18
+19	general	7000	20	18
+20	high_general	7500	20	18
+21	surface_marshal	7500	20	18

--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/FactionRankLoader.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/FactionRankLoader.kt
@@ -1,0 +1,57 @@
+/***********************************************************************************
+ * Copyright (c) 2026 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is an emulation project for Star Wars Galaxies founded on            *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create one or more emulators which will provide servers for      *
+ * players to continue playing a game similar to the one they used to play.        *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.resources.support.data.server_info.loader
+
+import com.projectswg.holocore.resources.support.data.server_info.SdbLoader
+import com.projectswg.holocore.resources.support.data.server_info.SdbLoader.SdbResultSet
+import java.io.File
+import java.io.IOException
+import java.util.*
+
+class FactionRankLoader internal constructor() : DataLoader() {
+	private val _ranks: MutableList<FactionRankInfo> = ArrayList()
+	val ranks: List<FactionRankInfo>
+		get() = Collections.unmodifiableList(_ranks)
+
+	fun getRank(index: Int): FactionRankInfo? = _ranks.getOrNull(index)
+
+	@Throws(IOException::class)
+	override fun load() {
+		SdbLoader.load(File("serverdata/faction/rank.sdb")).use { set ->
+			while (set.next()) {
+				_ranks.add(FactionRankInfo(set))
+			}
+		}
+	}
+
+	class FactionRankInfo(set: SdbResultSet) {
+		val index: Int = set.getInt("index").toInt()
+		val name: String = set.getText("name")
+		val cost: Int = set.getInt("cost").toInt()
+		val delegateRatioFrom: Int = set.getInt("delegate_ratio_from").toInt()
+		val delegateRatioTo: Int = set.getInt("delegate_ratio_to").toInt()
+	}
+}

--- a/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/ServerData.kt
+++ b/src/main/java/com/projectswg/holocore/resources/support/data/server_info/loader/ServerData.kt
@@ -45,6 +45,7 @@ object ServerData {
 	 */
 	val buffs				by SoftDataLoaderDelegate(::BuffLoader)
 	val factions			by SoftDataLoaderDelegate(::FactionLoader)
+	val factionRanks		by SoftDataLoaderDelegate(::FactionRankLoader)
 	val movements			by SoftDataLoaderDelegate(::MovementLoader)
 
 	/*

--- a/src/main/java/com/projectswg/holocore/services/gameplay/player/character/PlayerCharacterSheetService.kt
+++ b/src/main/java/com/projectswg/holocore/services/gameplay/player/character/PlayerCharacterSheetService.kt
@@ -30,6 +30,7 @@ package com.projectswg.holocore.services.gameplay.player.character
 import com.projectswg.common.network.packets.swg.zone.CharacterSheetResponseMessage
 import com.projectswg.common.network.packets.swg.zone.FactionResponseMessage
 import com.projectswg.holocore.intents.support.global.command.ExecuteCommandIntent
+import com.projectswg.holocore.resources.support.data.server_info.loader.ServerData
 import com.projectswg.holocore.resources.support.objects.swg.creature.CreatureObject
 import com.projectswg.holocore.resources.support.objects.swg.player.PlayerObject
 import me.joshlarson.jlcommon.control.IntentHandler
@@ -61,13 +62,19 @@ class PlayerCharacterSheetService : Service() {
 		val factionPointList = factionNameList.map { factionPoints.getOrDefault(it, 0) }.map { it.toFloat() }
 		creature.sendSelf(
 			FactionResponseMessage(
-				factionRank = "recruit",    // From datatables/faction/rank.iff, should be dynamic once we implement faction ranks
+				factionRank = factionRank(creature),
 				rebelPoints = factionPoints.getOrDefault("rebel", 0),
 				imperialPoints = factionPoints.getOrDefault("imperial", 0),
 				factionNames = factionNameList,
 				factionPoints = factionPointList
 			)
 		)
+	}
+
+	private fun factionRank(creature: CreatureObject): String {
+		val rank = ServerData.factionRanks.getRank(creature.factionRank.toInt())
+
+		return rank?.name ?: ""
 	}
 
 }

--- a/src/test/java/com/projectswg/holocore/resources/support/data/server_info/loader/FactionRankLoaderTest.kt
+++ b/src/test/java/com/projectswg/holocore/resources/support/data/server_info/loader/FactionRankLoaderTest.kt
@@ -1,0 +1,68 @@
+/***********************************************************************************
+ * Copyright (c) 2026 /// Project SWG /// www.projectswg.com                       *
+ *                                                                                 *
+ * ProjectSWG is an emulation project for Star Wars Galaxies founded on            *
+ * July 7th, 2011 after SOE announced the official shutdown of Star Wars Galaxies. *
+ * Our goal is to create one or more emulators which will provide servers for      *
+ * players to continue playing a game similar to the one they used to play.        *
+ *                                                                                 *
+ * This file is part of Holocore.                                                  *
+ *                                                                                 *
+ * --------------------------------------------------------------------------------*
+ *                                                                                 *
+ * Holocore is free software: you can redistribute it and/or modify                *
+ * it under the terms of the GNU Affero General Public License as                  *
+ * published by the Free Software Foundation, either version 3 of the              *
+ * License, or (at your option) any later version.                                 *
+ *                                                                                 *
+ * Holocore is distributed in the hope that it will be useful,                     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                  *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   *
+ * GNU Affero General Public License for more details.                             *
+ *                                                                                 *
+ * You should have received a copy of the GNU Affero General Public License        *
+ * along with Holocore.  If not, see <http://www.gnu.org/licenses/>.               *
+ ***********************************************************************************/
+package com.projectswg.holocore.resources.support.data.server_info.loader
+
+import com.projectswg.holocore.test.runners.TestRunnerNoIntents
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class FactionRankLoaderTest : TestRunnerNoIntents() {
+
+	@Test
+	fun ranksLoad() {
+		assertEquals(22, ServerData.factionRanks.ranks.size)
+	}
+
+	@Test
+	fun lowestRank() {
+		val recruit = ServerData.factionRanks.getRank(0)!!
+
+		assertEquals("recruit", recruit.name)
+		assertEquals(10, recruit.cost)
+		assertEquals(20, recruit.delegateRatioFrom)
+		assertEquals(2, recruit.delegateRatioTo)
+	}
+
+	@Test
+	fun highestRank() {
+		val surfaceMarshal = ServerData.factionRanks.getRank(21)!!
+
+		assertEquals("surface_marshal", surfaceMarshal.name)
+		assertEquals(7500, surfaceMarshal.cost)
+		assertEquals(18, surfaceMarshal.delegateRatioTo)
+	}
+
+	@Test
+	fun rankIndexMatchesPosition() {
+		ServerData.factionRanks.ranks.forEachIndexed { position, rank -> assertEquals(position, rank.index) }
+	}
+
+	@Test
+	fun rankAboveHighestIsUnknown() {
+		assertNull(ServerData.factionRanks.getRank(22))
+	}
+}

--- a/src/utility/java/com/projectswg/utility/ClientdataConvertAll.java
+++ b/src/utility/java/com/projectswg/utility/ClientdataConvertAll.java
@@ -28,6 +28,7 @@ public class ClientdataConvertAll {
 		Converters.QUESTLIST.load();
 		Converters.QUESTTASK.load();
 		Converters.SCHEMATIC_GROUP.load();
+		Converters.FACTION_RANK.load();
 	}
 	
 }

--- a/src/utility/java/com/projectswg/utility/clientdata/Converters.java
+++ b/src/utility/java/com/projectswg/utility/clientdata/Converters.java
@@ -22,6 +22,7 @@ public enum Converters {
 	QUESTLIST					(ConvertQuestLists::new),
 	QUESTTASK					(ConvertQuestTasks::new),
 	SCHEMATIC_GROUP				(() -> new ConvertDatatable("datatables/crafting/schematic_group.iff", "serverdata/crafting/schematic_group.sdb", true)),
+	FACTION_RANK				(() -> new ConvertDatatable("datatables/faction/rank.iff", "serverdata/faction/rank.sdb", true)),
 	STRINGS						(ConvertStrings::new),
 	TERRAINS					(ConvertTerrain::new);
 	


### PR DESCRIPTION
Auto generated from rank.iff clientdata file.

Eventually should be used for more than this, but for now it just makes the character sheet respond with the actual rank of the player instead of hardcoding `"recruit"`.

I have not been able to design a solution for the faction recruiter rank promotions that I like, so I'm just submitting these bits for now.

So to be clear: There is no way to increase your rank in-game. But once that's added, the character sheet will account for it. I have tested it - the text in the upper right corner of the window changes as expected.